### PR TITLE
feat(site): coming-soon wall + owner-bypass login

### DIFF
--- a/OWNER_ACCESS_SETUP.md
+++ b/OWNER_ACCESS_SETUP.md
@@ -1,0 +1,93 @@
+# Owner Access — Setup & Daily Use
+
+This site is walled behind a coming-soon page. Every visitor sees `/coming-soon` until launch.
+Van bypasses the wall via a hidden login at `/__owner-access`. After signing in once,
+a 90-day signed cookie keeps Van logged in on that browser/device.
+
+No new dependencies. Authentication uses the Web Crypto API (PBKDF2 + HMAC-SHA-256)
+and runs on Vercel's Edge runtime.
+
+---
+
+## 1. One-time setup (do this once, locally)
+
+You need to set two environment variables in Vercel.
+
+### Generate them
+
+From the repo root:
+
+```bash
+npm run generate-owner-secrets
+```
+
+The script prompts for a password (minimum 12 characters, not echoed back), then prints
+two lines:
+
+```
+OWNER_PASSWORD_HASH=<long hex string>:<long hex string>
+OWNER_COOKIE_SECRET=<long hex string>
+```
+
+### Paste them into Vercel
+
+1. Open the Vercel dashboard for the `zona-desert-site` project.
+2. Go to **Settings → Environment Variables**.
+3. Add two new variables, **Production scope only**:
+   - Name: `OWNER_PASSWORD_HASH` — Value: the full hex string after `=` from the script output.
+   - Name: `OWNER_COOKIE_SECRET` — Value: the full hex string after `=` from the script output.
+4. Click **Save** for each.
+
+### Redeploy
+
+Trigger a redeploy so Vercel picks up the new env vars (Deployments → … → Redeploy,
+or push any commit). The wall is now active.
+
+---
+
+## 2. Daily use
+
+1. Bookmark **`https://zonadesert.com/__owner-access`** in every browser/device you use.
+2. Visit the bookmark, enter the password, click **Continue**.
+3. You'll be redirected to the real site. The cookie lasts **90 days** in that browser.
+4. Every other visitor still sees the coming-soon page.
+
+Repeat the bookmark step on each browser/device you want access from.
+
+---
+
+## 3. Force re-auth / log out
+
+To clear your owner cookie on the current browser:
+
+```bash
+curl -X POST https://zonadesert.com/api/__owner-access/logout
+```
+
+…then re-visit `/__owner-access` to log back in. Or just clear cookies for `zonadesert.com`
+in your browser's site settings.
+
+---
+
+## 4. Forgot password
+
+1. Re-run `npm run generate-owner-secrets` locally with a new password.
+2. Update both `OWNER_PASSWORD_HASH` and `OWNER_COOKIE_SECRET` in Vercel
+   (Settings → Environment Variables).
+3. Trigger a redeploy.
+4. Note: rotating `OWNER_COOKIE_SECRET` invalidates every existing owner cookie,
+   so every device will need to re-auth at `/__owner-access`.
+
+---
+
+## Files involved
+
+| File | Purpose |
+|---|---|
+| `middleware.ts` | Edge middleware: rewrites every non-bypass route to `/coming-soon` unless the owner cookie verifies. |
+| `lib/owner-auth.ts` | PBKDF2 password verify + HMAC-SHA-256 cookie sign/verify. Web Crypto only. |
+| `app/coming-soon/page.tsx` | The aesthetic landing page everyone else sees. |
+| `app/__owner-access/page.tsx` | The hidden login form. |
+| `app/api/__owner-access/login/route.ts` | POST: verify password, set cookie. |
+| `app/api/__owner-access/logout/route.ts` | POST: clear cookie. |
+| `scripts/generate-owner-secrets.mjs` | Local utility (this script). |

--- a/app/%5F%5Fowner-access/page.tsx
+++ b/app/%5F%5Fowner-access/page.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { FormEvent, useState } from "react";
+
+export default function OwnerAccessPage() {
+  const [password, setPassword] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (submitting) return;
+    setError(null);
+    setSubmitting(true);
+    try {
+      const res = await fetch("/api/__owner-access/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ password }),
+        credentials: "same-origin"
+      });
+      if (res.ok) {
+        window.location.href = "/";
+        return;
+      }
+      if (res.status === 400) {
+        setError("Enter a password.");
+      } else {
+        setError("Wrong password.");
+      }
+    } catch {
+      setError("Something went wrong. Try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <main
+      data-zona-gate="1"
+      className="min-h-screen w-full bg-[#F1F2EF] text-[#0E172A] flex items-center justify-center px-6 py-16"
+    >
+      <div className="w-full max-w-sm">
+        <h1
+          className="text-2xl font-semibold text-[#0E172A] tracking-tight mb-6"
+          style={{ fontFamily: "var(--font-sora), system-ui, sans-serif" }}
+        >
+          Owner access
+        </h1>
+
+        <form
+          onSubmit={handleSubmit}
+          className="flex flex-col gap-4"
+          style={{ fontFamily: "var(--font-inter), system-ui, sans-serif" }}
+        >
+          <label htmlFor="owner-password" className="sr-only">
+            Password
+          </label>
+          <input
+            id="owner-password"
+            type="password"
+            autoComplete="current-password"
+            autoFocus
+            required
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="Password"
+            className="w-full rounded-lg border border-[#0E172A]/15 bg-white px-4 py-3 text-base text-[#0E172A] placeholder:text-[#0E172A]/40 outline-none transition focus:border-[#4A1988] focus:ring-2 focus:ring-[#4A1988]/30"
+          />
+
+          {error && (
+            <p role="alert" className="text-sm text-[#FE642D]">
+              {error}
+            </p>
+          )}
+
+          <button
+            type="submit"
+            disabled={submitting || !password}
+            className="w-full rounded-lg bg-[#4A1988] px-4 py-3 text-base font-semibold text-white transition hover:bg-[#7025B6] disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {submitting ? "Verifying..." : "Continue"}
+          </button>
+        </form>
+      </div>
+    </main>
+  );
+}

--- a/app/api/%5F%5Fowner-access/login/route.ts
+++ b/app/api/%5F%5Fowner-access/login/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  OWNER_COOKIE_NAME,
+  OWNER_COOKIE_MAX_AGE_SECONDS,
+  signOwnerCookie,
+  verifyPassword
+} from "@/lib/owner-auth";
+
+export const runtime = "edge";
+export const dynamic = "force-dynamic";
+
+const DEFENSIVE_DELAY_MS = 250;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function POST(req: NextRequest) {
+  let payload: unknown;
+  try {
+    payload = await req.json();
+  } catch {
+    return NextResponse.json({ ok: false }, { status: 400 });
+  }
+
+  const password =
+    typeof payload === "object" && payload !== null && typeof (payload as { password?: unknown }).password === "string"
+      ? (payload as { password: string }).password
+      : "";
+
+  if (!password) {
+    return NextResponse.json({ ok: false }, { status: 400 });
+  }
+
+  const [valid] = await Promise.all([verifyPassword(password), delay(DEFENSIVE_DELAY_MS)]);
+  if (!valid) {
+    return NextResponse.json({ ok: false }, { status: 401 });
+  }
+
+  const cookieValue = await signOwnerCookie();
+  if (!cookieValue) {
+    return NextResponse.json({ ok: false }, { status: 500 });
+  }
+
+  const res = NextResponse.json({ ok: true });
+  res.cookies.set({
+    name: OWNER_COOKIE_NAME,
+    value: cookieValue,
+    httpOnly: true,
+    secure: true,
+    sameSite: "lax",
+    path: "/",
+    maxAge: OWNER_COOKIE_MAX_AGE_SECONDS
+  });
+  return res;
+}

--- a/app/api/%5F%5Fowner-access/logout/route.ts
+++ b/app/api/%5F%5Fowner-access/logout/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { OWNER_COOKIE_NAME } from "@/lib/owner-auth";
+
+export const runtime = "edge";
+export const dynamic = "force-dynamic";
+
+export async function POST() {
+  const res = NextResponse.json({ ok: true });
+  res.cookies.set({
+    name: OWNER_COOKIE_NAME,
+    value: "",
+    httpOnly: true,
+    secure: true,
+    sameSite: "lax",
+    path: "/",
+    maxAge: 0
+  });
+  return res;
+}

--- a/app/coming-soon/page.tsx
+++ b/app/coming-soon/page.tsx
@@ -1,0 +1,88 @@
+import Image from "next/image";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Zona Desert | Coming soon",
+  description: "Zona Desert Property Solutions — coming soon."
+};
+
+const FACEBOOK_URL = "https://www.facebook.com/share/1J4m5omk6L/?mibextid=wwXIfr";
+const INSTAGRAM_URL =
+  "https://www.instagram.com/zona.desert?igsh=MXNkbTNzM205bGg0MQ%3D%3D&utm_source=qr";
+
+const FACEBOOK_PATH =
+  "M9.101 23.691v-7.98H6.627v-3.667h2.474v-1.58c0-4.085 1.848-5.978 5.858-5.978.401 0 .955.042 1.468.103a8.68 8.68 0 0 1 1.141.195v3.325a8.623 8.623 0 0 0-.653-.036 26.805 26.805 0 0 0-.733-.009c-.707 0-1.259.096-1.675.309a1.686 1.686 0 0 0-.679.622c-.258.42-.374.995-.374 1.752v1.297h3.919l-.386 2.103-.287 1.564h-3.246v8.245C19.396 23.238 24 18.179 24 12.044c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.628 3.874 10.35 9.101 11.647Z";
+const INSTAGRAM_PATH =
+  "M12 0C8.74 0 8.333.015 7.053.072 5.775.132 4.905.333 4.14.63c-.789.306-1.459.717-2.126 1.384S.935 3.35.63 4.14C.333 4.905.131 5.775.072 7.053.012 8.333 0 8.74 0 12s.015 3.667.072 4.947c.06 1.277.261 2.148.558 2.913.306.788.717 1.459 1.384 2.126.667.666 1.336 1.079 2.126 1.384.766.296 1.636.499 2.913.558C8.333 23.988 8.74 24 12 24s3.667-.015 4.947-.072c1.277-.06 2.148-.262 2.913-.558.788-.306 1.459-.718 2.126-1.384.666-.667 1.079-1.335 1.384-2.126.296-.765.499-1.636.558-2.913.06-1.28.072-1.687.072-4.947s-.015-3.667-.072-4.947c-.06-1.277-.262-2.149-.558-2.913-.306-.789-.718-1.459-1.384-2.126C21.319 1.347 20.651.935 19.86.63c-.765-.297-1.636-.499-2.913-.558C15.667.012 15.26 0 12 0Zm0 2.16c3.203 0 3.585.016 4.85.071 1.17.055 1.805.249 2.227.415.562.217.96.477 1.382.896.419.42.679.819.896 1.381.164.422.36 1.057.413 2.227.057 1.266.07 1.646.07 4.85s-.015 3.585-.074 4.85c-.061 1.17-.256 1.805-.421 2.227-.224.562-.479.96-.899 1.382-.419.419-.824.679-1.38.896-.42.164-1.065.36-2.235.413-1.274.057-1.649.07-4.859.07-3.211 0-3.586-.015-4.859-.074-1.171-.061-1.816-.256-2.236-.421-.569-.224-.96-.479-1.379-.899-.421-.419-.69-.824-.9-1.38-.165-.42-.359-1.065-.42-2.235-.045-1.26-.061-1.649-.061-4.844 0-3.196.016-3.586.061-4.861.061-1.17.255-1.814.42-2.234.21-.57.479-.96.9-1.381.419-.419.81-.689 1.379-.898.42-.166 1.051-.361 2.221-.421 1.275-.045 1.65-.06 4.859-.06l.045.03Zm0 3.678c-3.405 0-6.162 2.76-6.162 6.162 0 3.405 2.76 6.162 6.162 6.162 3.405 0 6.162-2.76 6.162-6.162 0-3.405-2.76-6.162-6.162-6.162ZM12 16c-2.21 0-4-1.79-4-4s1.79-4 4-4 4 1.79 4 4-1.79 4-4 4Zm7.846-10.405c0 .795-.646 1.44-1.44 1.44-.795 0-1.44-.646-1.44-1.44 0-.794.646-1.439 1.44-1.439.793-.001 1.44.645 1.44 1.439Z";
+
+export default function ComingSoonPage() {
+  return (
+    <main
+      data-zona-gate="1"
+      className="min-h-screen w-full bg-[#F1F2EF] text-[#0E172A] flex flex-col items-center justify-center px-6 py-16"
+    >
+      <div className="flex flex-col items-center gap-10 sm:gap-12 text-center">
+        <Image
+          src="/zona-wordmark.png"
+          alt="Zona Desert Property Solutions"
+          width={420}
+          height={108}
+          priority
+          className="w-auto h-auto max-w-[80vw] sm:max-w-[420px]"
+        />
+
+        <h1
+          className="text-3xl sm:text-4xl font-semibold text-[#0E172A] tracking-tight"
+          style={{ fontFamily: "var(--font-sora), system-ui, sans-serif" }}
+        >
+          Coming soon...
+        </h1>
+
+        <div
+          className="flex flex-col items-center gap-4"
+          style={{ fontFamily: "var(--font-inter), system-ui, sans-serif" }}
+        >
+          <p className="text-sm text-[#0E172A]/70">Follow us</p>
+          <div className="flex items-center gap-6 text-[#0E172A]/70">
+            <a
+              href={FACEBOOK_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Facebook"
+              className="transition-colors hover:text-[#4A1988]"
+            >
+              <svg
+                viewBox="0 0 24 24"
+                width="32"
+                height="32"
+                fill="currentColor"
+                aria-hidden="true"
+                role="img"
+              >
+                <path d={FACEBOOK_PATH} />
+              </svg>
+            </a>
+            <a
+              href={INSTAGRAM_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Instagram"
+              className="transition-colors hover:text-[#4A1988]"
+            >
+              <svg
+                viewBox="0 0 24 24"
+                width="32"
+                height="32"
+                fill="currentColor"
+                aria-hidden="true"
+                role="img"
+              >
+                <path d={INSTAGRAM_PATH} />
+              </svg>
+            </a>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -13,3 +13,11 @@ body {
 main {
   @apply flex-1;
 }
+
+/* Suppress the global cookie consent banner on owner-gate routes (/coming-soon, /__owner-access).
+   Pages opt in via a [data-zona-gate="1"] attribute on their root element. The banner is rendered
+   as a sibling of page content inside <body>, so :has() lets us scope without modifying
+   the protected CookieConsentProvider component. */
+body:has([data-zona-gate="1"]) > .fixed.bottom-0.left-0.right-0.z-40 {
+  display: none !important;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,22 @@
 import type { Metadata } from "next";
+import { Sora, Inter } from "next/font/google";
 import "./globals.css";
 import { CookieConsentProvider } from "@/components/CookieConsentProvider";
+
+const sora = Sora({
+  subsets: ["latin"],
+  weight: ["600"],
+  variable: "--font-sora",
+  display: "swap"
+});
+
+const inter = Inter({
+  subsets: ["latin"],
+  weight: ["400", "500"],
+  variable: "--font-inter",
+  display: "swap"
+});
+
 export const metadata: Metadata = {
   title: "Zona Desert | Investor-First Real Estate Marketplace",
   description: "Curated private-market deals for buyers, investors, and creative finance pros nationwide."
@@ -8,7 +24,7 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
+    <html lang="en" className={`${sora.variable} ${inter.variable}`}>
       <body className="bg-gradient-to-b from-white to-slate-50">
         <CookieConsentProvider>
           {children}

--- a/lib/owner-auth.ts
+++ b/lib/owner-auth.ts
@@ -1,0 +1,138 @@
+// Edge-runtime safe owner auth utilities (Web Crypto API only).
+// Used by middleware.ts + app/api/__owner-access/* routes.
+// Mirror these constants in scripts/generate-owner-secrets.mjs.
+
+export const PBKDF2_ITERATIONS = 600_000;
+export const PBKDF2_HASH = "SHA-256" as const;
+export const SALT_BYTES = 16;
+export const DERIVED_KEY_BYTES = 32;
+export const COOKIE_SECRET_BYTES = 32;
+
+export const OWNER_COOKIE_NAME = "__zona_owner_access";
+export const OWNER_COOKIE_MAX_AGE_SECONDS = 90 * 24 * 60 * 60; // 90 days
+
+function hexToBytes(hex: string): Uint8Array {
+  if (hex.length % 2 !== 0) throw new Error("invalid hex length");
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    const byte = parseInt(hex.substr(i * 2, 2), 16);
+    if (Number.isNaN(byte)) throw new Error("invalid hex character");
+    out[i] = byte;
+  }
+  return out;
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  let s = "";
+  for (let i = 0; i < bytes.length; i++) {
+    s += bytes[i].toString(16).padStart(2, "0");
+  }
+  return s;
+}
+
+function constantTimeEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a[i] ^ b[i];
+  return diff === 0;
+}
+
+async function pbkdf2(
+  password: string,
+  salt: Uint8Array,
+  iterations: number,
+  keyLenBytes: number
+): Promise<Uint8Array> {
+  const baseKey = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(password) as BufferSource,
+    { name: "PBKDF2" },
+    false,
+    ["deriveBits"]
+  );
+  const bits = await crypto.subtle.deriveBits(
+    { name: "PBKDF2", salt: salt as BufferSource, iterations, hash: PBKDF2_HASH },
+    baseKey,
+    keyLenBytes * 8
+  );
+  return new Uint8Array(bits);
+}
+
+async function hmacSha256(keyBytes: Uint8Array, message: string): Promise<Uint8Array> {
+  const cryptoKey = await crypto.subtle.importKey(
+    "raw",
+    keyBytes as BufferSource,
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  const sig = await crypto.subtle.sign(
+    "HMAC",
+    cryptoKey,
+    new TextEncoder().encode(message) as BufferSource
+  );
+  return new Uint8Array(sig);
+}
+
+export async function verifyPassword(password: string): Promise<boolean> {
+  if (!password) return false;
+  const stored = process.env.OWNER_PASSWORD_HASH;
+  if (!stored) return false;
+  const sep = stored.indexOf(":");
+  if (sep <= 0 || sep === stored.length - 1) return false;
+  const saltHex = stored.slice(0, sep);
+  const expectedHex = stored.slice(sep + 1);
+  let salt: Uint8Array;
+  let expected: Uint8Array;
+  try {
+    salt = hexToBytes(saltHex);
+    expected = hexToBytes(expectedHex);
+  } catch {
+    return false;
+  }
+  if (salt.length !== SALT_BYTES || expected.length !== DERIVED_KEY_BYTES) return false;
+  const derived = await pbkdf2(password, salt, PBKDF2_ITERATIONS, DERIVED_KEY_BYTES);
+  return constantTimeEqual(derived, expected);
+}
+
+function getCookieSecret(): Uint8Array | null {
+  const hex = process.env.OWNER_COOKIE_SECRET;
+  if (!hex) return null;
+  try {
+    const bytes = hexToBytes(hex);
+    if (bytes.length < 16) return null;
+    return bytes;
+  } catch {
+    return null;
+  }
+}
+
+export async function signOwnerCookie(): Promise<string | null> {
+  const secret = getCookieSecret();
+  if (!secret) return null;
+  const expiry = Math.floor(Date.now() / 1000) + OWNER_COOKIE_MAX_AGE_SECONDS;
+  const payload = String(expiry);
+  const sig = await hmacSha256(secret, payload);
+  return `${payload}.${bytesToHex(sig)}`;
+}
+
+export async function verifyOwnerCookie(cookie: string | undefined | null): Promise<boolean> {
+  if (!cookie) return false;
+  const dot = cookie.indexOf(".");
+  if (dot <= 0 || dot === cookie.length - 1) return false;
+  const payload = cookie.slice(0, dot);
+  const sigHex = cookie.slice(dot + 1);
+  const expiry = Number(payload);
+  if (!Number.isFinite(expiry) || expiry <= 0) return false;
+  if (Math.floor(Date.now() / 1000) >= expiry) return false;
+  const secret = getCookieSecret();
+  if (!secret) return false;
+  let presented: Uint8Array;
+  try {
+    presented = hexToBytes(sigHex);
+  } catch {
+    return false;
+  }
+  const expected = await hmacSha256(secret, payload);
+  return constantTimeEqual(presented, expected);
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from "next/server";
+import { OWNER_COOKIE_NAME, verifyOwnerCookie } from "@/lib/owner-auth";
+
+const BYPASS_PREFIXES = [
+  "/__owner-access",
+  "/api/__owner-access",
+  "/coming-soon",
+  "/_next",
+  "/favicon.ico",
+  "/robots.txt",
+  "/sitemap.xml",
+  "/zona-",
+  "/logo.png"
+];
+
+function shouldBypass(pathname: string): boolean {
+  for (const prefix of BYPASS_PREFIXES) {
+    if (pathname === prefix || pathname.startsWith(prefix)) return true;
+  }
+  return false;
+}
+
+export async function middleware(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+  if (shouldBypass(pathname)) return NextResponse.next();
+
+  const cookie = req.cookies.get(OWNER_COOKIE_NAME)?.value;
+  const ok = await verifyOwnerCookie(cookie);
+  if (ok) return NextResponse.next();
+
+  const url = req.nextUrl.clone();
+  url.pathname = "/coming-soon";
+  url.search = "";
+  return NextResponse.rewrite(url);
+}
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"]
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "generate-owner-secrets": "node scripts/generate-owner-secrets.mjs"
   },
   "dependencies": {
     "@vercel/analytics": "^1.6.1",

--- a/scripts/generate-owner-secrets.mjs
+++ b/scripts/generate-owner-secrets.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+// Local-only utility: generate OWNER_PASSWORD_HASH + OWNER_COOKIE_SECRET for Vercel env vars.
+// Mirrors the constants in lib/owner-auth.ts so the produced hash verifies in the Edge runtime.
+//
+// Usage: npm run generate-owner-secrets
+
+import { webcrypto } from "node:crypto";
+import { stdin as input, stdout as output } from "node:process";
+import readline from "node:readline/promises";
+
+// MUST match lib/owner-auth.ts exactly.
+const PBKDF2_ITERATIONS = 600_000;
+const PBKDF2_HASH = "SHA-256";
+const SALT_BYTES = 16;
+const DERIVED_KEY_BYTES = 32;
+const COOKIE_SECRET_BYTES = 32;
+
+const MIN_PASSWORD_LENGTH = 12;
+
+function bytesToHex(bytes) {
+  let s = "";
+  for (let i = 0; i < bytes.length; i++) {
+    s += bytes[i].toString(16).padStart(2, "0");
+  }
+  return s;
+}
+
+async function pbkdf2(password, salt, iterations, keyLenBytes) {
+  const baseKey = await webcrypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(password),
+    { name: "PBKDF2" },
+    false,
+    ["deriveBits"]
+  );
+  const bits = await webcrypto.subtle.deriveBits(
+    { name: "PBKDF2", salt, iterations, hash: PBKDF2_HASH },
+    baseKey,
+    keyLenBytes * 8
+  );
+  return new Uint8Array(bits);
+}
+
+async function main() {
+  const rl = readline.createInterface({ input, output, terminal: true });
+  let password;
+  try {
+    password = await rl.question(
+      `Enter the owner password (min ${MIN_PASSWORD_LENGTH} chars). It will not be echoed back: `
+    );
+  } finally {
+    rl.close();
+  }
+
+  if (!password || password.length < MIN_PASSWORD_LENGTH) {
+    console.error(`\nError: password must be at least ${MIN_PASSWORD_LENGTH} characters.`);
+    process.exit(1);
+  }
+
+  const salt = webcrypto.getRandomValues(new Uint8Array(SALT_BYTES));
+  const derived = await pbkdf2(password, salt, PBKDF2_ITERATIONS, DERIVED_KEY_BYTES);
+  const cookieSecret = webcrypto.getRandomValues(new Uint8Array(COOKIE_SECRET_BYTES));
+
+  const ownerPasswordHash = `${bytesToHex(salt)}:${bytesToHex(derived)}`;
+  const ownerCookieSecret = bytesToHex(cookieSecret);
+
+  output.write("\n");
+  output.write("Add these two environment variables to Vercel (Production scope):\n\n");
+  output.write(`OWNER_PASSWORD_HASH=${ownerPasswordHash}\n`);
+  output.write(`OWNER_COOKIE_SECRET=${ownerCookieSecret}\n`);
+  output.write("\n");
+  output.write("Steps:\n");
+  output.write("  1. Open Vercel project Settings -> Environment Variables.\n");
+  output.write("  2. Paste both lines above (Production scope only).\n");
+  output.write("  3. Trigger a redeploy so the new vars are picked up.\n");
+  output.write("  4. Visit https://zonadesert.com/__owner-access and sign in.\n");
+  output.write("\nDo NOT commit these values. Re-run this script anytime to rotate.\n");
+}
+
+main().catch((err) => {
+  console.error("Failed to generate owner secrets:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Public Site Wall — Coming Soon + Owner Bypass

Edge middleware gates entire zonadesert.com behind aesthetic coming-soon page (logo + Sora/Inter + Facebook + Instagram + "Follow us" + "Coming soon..."). Hidden `/__owner-access` login bypasses gate via 90-day signed cookie. Web Crypto API only — zero npm deps.

**Files added:**
- `middleware.ts` — edge gate
- `lib/owner-auth.ts` — Web Crypto utilities (PBKDF2 + HMAC-SHA-256)
- `app/coming-soon/page.tsx` — aesthetic landing
- `app/__owner-access/page.tsx` — hidden login form
- `app/api/__owner-access/{login,logout}/route.ts` — POST endpoints
- `scripts/generate-owner-secrets.mjs` — local utility for Van
- `OWNER_ACCESS_SETUP.md` — setup instructions

**Existing routes byte-identical:** `(sell-submit)`, `(site)`, `api/consent-log`, `api/deal-pack`, `deal-pack` — middleware rewrites the URL when unauthed; underlying handlers UNTOUCHED.

**Post-merge setup (see OWNER_ACCESS_SETUP.md):**
1. `npm run generate-owner-secrets` locally → enter password
2. Paste `OWNER_PASSWORD_HASH` + `OWNER_COOKIE_SECRET` into Vercel env vars (Production)
3. Trigger redeploy

**Owner access:** Van bookmarks https://zonadesert.com/__owner-access (90-day cookie per browser).

---

### Notable agent judgment (Rule 10.21)

1. **Folder name `__owner-access` is a Next.js private folder.** Initial build manifest had no `/__owner-access` or `/api/__owner-access/*` routes — Next.js excludes any folder whose name begins with `_` from routing. Per Next.js docs, to render an underscore in the URL the folder must be named with the URL-encoded form `%5F`. Renamed `app/__owner-access/` → `app/%5F%5Fowner-access/` and `app/api/__owner-access/` → `app/api/%5F%5Fowner-access/`. The actual URLs (`/__owner-access`, `/api/__owner-access/{login,logout}`) and the middleware bypass list match the prompt spec exactly. Re-built; routes now appear in the manifest. Without this catch the entire owner-bypass path 404s.

2. **Logo aspect ratio.** Prompt suggested `width={420} height={120}` but `public/zona-wordmark.png` is `796x205` (3.88:1). Used `width={420} height={108}` to preserve natural ratio with `className="w-auto h-auto max-w-[80vw] sm:max-w-[420px]"` so it scales cleanly without distortion.

3. **Cookie banner suppression strategy.** `components/CookieConsentProvider.tsx` is byte-identical-protected, so the cleanest available scope was an additive CSS rule in `app/globals.css` using `:has()` to hide the banner whenever the rendered page sets `data-zona-gate="1"` on its root element. Both `/coming-soon` and `/__owner-access` opt in. Zero impact on any other route. CookieConsentProvider untouched.

4. **Font-loading scope.** Prompt offered "load globally vs page-only" — went global as CSS variables (`--font-sora`, `--font-inter`) on the `<html>` element via `next/font/google`. The variables are exposed everywhere but applied via inline `style={{ fontFamily: "var(--font-sora)..." }}` only on the gate pages, so existing routes have zero visual change. Diff to `app/layout.tsx` is +12 lines (2 imports + 2 const + 2 className tokens), no rendering change for any existing page.

5. **TypeScript Uint8Array generic strictness.** `@types/node` (5.4) types `crypto.subtle.deriveBits/sign` parameters as `BufferSource = ArrayBufferView<ArrayBuffer>`, but the default `Uint8Array` constructor returns `Uint8Array<ArrayBufferLike>` which can include `SharedArrayBuffer`. Added `as BufferSource` casts at the call sites — narrower than copying the bytes through a fresh `ArrayBuffer`, identical runtime behavior.

### Verification performed locally

- `npx tsc --noEmit` — clean
- `npm run lint` — clean (`✔ No ESLint warnings or errors`)
- `npm run build` — succeeds; `/__owner-access`, `/api/__owner-access/login`, `/api/__owner-access/logout`, `/coming-soon` all in route manifest
- `npm run generate-owner-secrets` — ran end-to-end with throwaway password `test-password-12345`, produced valid env-var format
- **Crypto round-trip verified:** independently re-derived PBKDF2 output from the script's salt against the script's hash — match
- **Full gate cycle verified against `next dev`:**
  - Unauthed `GET /` → coming-soon HTML (15 KB, "Coming soon" present)
  - Unauthed `GET /listings` → coming-soon HTML (rewritten by middleware, URL stays `/listings`)
  - `GET /__owner-access` → login form HTML
  - `POST /api/__owner-access/login` (wrong password) → `401 {"ok":false}`
  - `POST /api/__owner-access/login` (correct password) → `200 {"ok":true}` + sets `__zona_owner_access` HttpOnly cookie
  - Authed `GET /` → real homepage HTML (33 KB, hero-bg.png preload — the real site)
  - `POST /api/__owner-access/logout` → `200 {"ok":true}` + clears cookie
  - Post-logout `GET /` → coming-soon HTML again

### Constraints honored

- Zero new npm dependencies (`package-lock.json` unchanged)
- No `node:*` imports in `lib/owner-auth.ts`, `middleware.ts`, or either route handler
- Both API routes declare `export const runtime = "edge"`
- `.env.production.local` left untracked
- Local `.gitignore` modification NOT staged
- All existing routes byte-identical
- `tailwind.config.ts` byte-identical (used arbitrary value classes for brand colors)
- No secrets committed