### PR TITLE
fix(site): allow /brand assets through middleware + add bg fallback color

### DIFF
--- a/app/coming-soon/page.tsx
+++ b/app/coming-soon/page.tsx
@@ -21,7 +21,7 @@ export default function ComingSoonPage() {
   return (
     <main
       data-zona-gate="1"
-      className="min-h-screen w-full text-white flex flex-col items-center justify-between px-6 py-16"
+      className="min-h-screen w-full bg-[#4A1988] text-white flex flex-col items-center justify-between px-6 py-16"
       style={{
         backgroundImage: "url(/brand/desert-site-wall-background.png)",
         backgroundSize: "cover",

--- a/middleware.ts
+++ b/middleware.ts
@@ -10,6 +10,7 @@ const BYPASS_PREFIXES = [
   "/robots.txt",
   "/sitemap.xml",
   "/zona-",
+  "/brand",
   "/logo.png"
 ];
 


### PR DESCRIPTION
## Hot fix

Site rendered fully white after PR #8 because:

1. **Middleware was eating asset requests.** PR #8 moved logo and bg image into `public/brand/` subfolder, but `BYPASS_PREFIXES` in middleware.ts had `/zona-` and `/logo.png` only — `/brand` wasn't listed. Browser requests for `/brand/desert-site-wall-background.png` and `/brand/zona-logo-secondary-light.png` were caught by the gate and rewritten to `/coming-soon` HTML. Verified with `curl -I`: returned HTTP 200 with `content-type: text/html` instead of an image.

2. **No fallback bg color.** PR #8 removed `bg-[#4A1988]` Tailwind class in favor of inline-style background-image. With the image failing to load (root cause #1), the page had no background color → white. White text + white logo on white = invisible content.

## Fix

**middleware.ts:** Add `/brand` to `BYPASS_PREFIXES` (one line). Same pattern as the existing `/zona-` bypass which covers PR #7's `public/zona-logo-mark.png`.

**app/coming-soon/page.tsx:** Add `bg-[#4A1988]` fallback color to outer main. Defense in depth — if the bg image ever fails again, the page still shows brand purple-deep with visible content rather than white-out.

## Verification (post-merge)

```bash
curl -I https://zonadesert.com/brand/desert-site-wall-background.png
# Expected: HTTP 200 + content-type: image/png + size: ~1.3MB
```

## Scope

2 files, 3 lines. No other changes. Owner-access infrastructure untouched. All existing site routes untouched.