### PR TITLE
fix(site): coming-soon visual polish — 6 adjustments per Van direction

### DIFF
--- a/app/coming-soon/page.tsx
+++ b/app/coming-soon/page.tsx
@@ -25,7 +25,7 @@ export default function ComingSoonPage() {
       style={{
         backgroundImage: "url(/brand/desert-site-wall-background.png)",
         backgroundSize: "cover",
-        backgroundPosition: "center",
+        backgroundPosition: "65% center",
         backgroundRepeat: "no-repeat",
       }}
     >
@@ -34,25 +34,32 @@ export default function ComingSoonPage() {
           <Image
             src="/brand/zona-logo-secondary-light.png"
             alt="Zona Desert Property Solutions"
-            width={400}
-            height={267}
+            width={480}
+            height={320}
             priority
-            className="w-auto h-auto max-w-[80vw] sm:max-w-[400px] mb-12"
+            className="w-auto h-auto max-w-[88vw] sm:max-w-[480px] mt-8 mb-6"
           />
 
           <h1
-            className="text-3xl sm:text-4xl font-semibold text-white tracking-tight mb-16"
+            className="text-3xl sm:text-4xl font-semibold text-white tracking-tight mb-3"
             style={{ fontFamily: "var(--font-sora), system-ui, sans-serif" }}
           >
             Coming soon...
           </h1>
+
+          <p
+            className="text-base sm:text-lg text-white/85 mb-16"
+            style={{ fontFamily: "var(--font-inter), system-ui, sans-serif", fontWeight: 300 }}
+          >
+            Something <span style={{ fontWeight: 600 }}>extraordinary</span> is on the horizon.
+          </p>
 
           <div
             className="flex flex-col items-center gap-6"
             style={{ fontFamily: "var(--font-inter), system-ui, sans-serif" }}
           >
             <p className="text-sm text-white/70">Follow us</p>
-            <div className="flex items-start gap-10">
+            <div className="flex items-stretch gap-8">
               <a
                 href={FACEBOOK_URL}
                 target="_blank"
@@ -74,6 +81,10 @@ export default function ComingSoonPage() {
                   {SOCIAL_HANDLE}
                 </span>
               </a>
+              <div
+                aria-hidden="true"
+                className="self-stretch w-px bg-white/25"
+              />
               <a
                 href={INSTAGRAM_URL}
                 target="_blank"
@@ -105,7 +116,7 @@ export default function ComingSoonPage() {
         className="text-white/40 hover:text-white/70 text-sm transition-colors mt-16"
         style={{ fontFamily: "var(--font-inter), system-ui, sans-serif" }}
       >
-        Owner login →
+        Access code →
       </Link>
     </main>
   );


### PR DESCRIPTION
Per Van's screenshot review:

1. **Logo bigger + lower** — 400px→480px, added `mt-8`, tighter `mb-6`
2. **'Coming soon...' moved up** — `mb-16`→`mb-3` (tight under logo)
3. **New subtitle** — 'Something **extraordinary** is on the horizon.' in Inter (secondary font), light weight 300, with 'extraordinary' bolded at weight 600
4. **Vertical divider** between Facebook and Instagram — 1px wide, `bg-white/25`, `self-stretch` to match link heights
5. **Mountain peak alignment** — `backgroundPosition` shifted from `center` to `65% center`. Programmatic analysis of the source bg image found the brightness centroid at 57.5% and brightest pixel at 64.8%. Setting bgPosition X to 65% shifts the visible window so the peak region lands closer to viewport center.
6. **'Owner login →' → 'Access code →'** (link target unchanged)

May need a follow-up iteration on the bg position depending on how it renders across viewport widths — 'cover' scales differently per aspect ratio. We'll see after deploy.

Files: 1 changed, +18/-7. No middleware or infrastructure touched.