### PR TITLE
chore(ci): add lint + build workflow for zona-desert-site

### DIFF
--- a/.github/workflows/lint-and-build.yml
+++ b/.github/workflows/lint-and-build.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  lint-and-build:
+    name: Lint + Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
## Summary

Minimal CI for `zona-desert-site` — runs `npm run lint` + `npm run build` on every PR + push to `main`.

## Why now

Establishes the auto-merge baseline ahead of **Phase 4.5.g (Public Portal Frontend)** which will be the first non-trivial PR landing in this repo.

Without CI:
- No automated lint check
- No build verification before merge
- Auto-merge rule ("clean PR + green CI = merge") doesn't apply
- All future PRs require manual Vercel preview review

With CI:
- Lint catches Tailwind/TypeScript issues
- Build catches type errors + missing imports + bundle issues
- Auto-merge applies to all future zona-desert-site PRs
- Vercel preview deploy remains as additional belt-and-suspenders

## What's in this workflow

Single job `lint-and-build` running on `ubuntu-latest`:
1. Checkout
2. Setup Node 20 LTS with built-in npm cache (`actions/setup-node@v4` — no separate cache step needed)
3. `npm ci`
4. `npm run lint` (= `next lint`)
5. `npm run build` (= `next build`)

29 lines. One file. Standard Next.js CI setup.

## Test plan

- This PR itself will be the first one to run the new workflow (meta but works — workflow file added in this PR runs on the PR that adds it)
- After merge, all future PRs automatically get lint + build verification
- Vercel preview deploy continues to fire in parallel as a deployment smoke test

## Cost

GitHub Actions free tier: 2000 minutes/month for private repos. This workflow runs ~2-3 minutes per PR. Even with daily PRs, monthly usage stays under 100 minutes. Effectively free.

🤖 Generated with [Claude](https://claude.ai)