### PR TITLE
feat(site): public offer portal foundation — Hero + brand tokens (Phase 4.5.g)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,6 +4,12 @@
 
 :root {
   color-scheme: light;
+  --color-purple-deep: #4A1988;
+  --color-purple-mid: #7025B6;
+  --color-orange: #FE642D;
+  --color-amber: #FEA91E;
+  --color-navy: #0E172A;
+  --color-off-white: #F1F2EF;
 }
 
 body {

--- a/app/offer/[token]/not-found.tsx
+++ b/app/offer/[token]/not-found.tsx
@@ -1,0 +1,51 @@
+import Image from "next/image";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Offer not found | Zona Desert",
+  robots: {
+    index: false,
+    follow: false
+  }
+};
+
+export default function OfferNotFound() {
+  return (
+    <main
+      data-zona-gate="1"
+      className="flex min-h-screen flex-col items-center justify-center bg-zona-off-white px-6 py-16"
+    >
+      <div className="w-full max-w-xl space-y-8 text-center">
+        <div className="mx-auto h-16 w-16 relative">
+          <Image
+            src="/brand/zona-logo-icon.png"
+            alt="Zona Desert"
+            fill
+            sizes="64px"
+            className="object-contain"
+            priority
+          />
+        </div>
+        <h1
+          className="text-3xl text-zona-navy"
+          style={{ fontFamily: "var(--font-sora)", fontWeight: 600 }}
+        >
+          This offer link isn&apos;t valid or has been removed.
+        </h1>
+        <p
+          className="text-base text-zona-navy/70"
+          style={{ fontFamily: "var(--font-inter)" }}
+        >
+          If you believe this is a mistake, reach us at{" "}
+          <a
+            href="mailto:hello@zonadesert.com"
+            className="text-zona-purple-mid underline"
+          >
+            hello@zonadesert.com
+          </a>
+          .
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/app/offer/[token]/page.tsx
+++ b/app/offer/[token]/page.tsx
@@ -1,0 +1,34 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { fetchPublicOffer } from "@/lib/publicApi";
+import { OfferHero } from "@/components/portal/OfferHero";
+import { TerminalState } from "@/components/portal/TerminalState";
+
+// Token-gated content must never be indexed. Robots noindex/nofollow per
+// blueprint §3.1 (Token-Based Access).
+export const metadata: Metadata = {
+  title: "Your Zona Desert Offer",
+  robots: {
+    index: false,
+    follow: false,
+    nocache: true,
+    googleBot: {
+      index: false,
+      follow: false
+    }
+  }
+};
+
+// Server Component — token fetch happens server-side (no CORS, never
+// cached). Dispatch to the client OfferHero for the active-state
+// countdown timer; terminal states render via TerminalState (no
+// interactivity needed).
+export default async function OfferPage({ params }: { params: { token: string } }) {
+  const offer = await fetchPublicOffer(params.token);
+  if (!offer) notFound();
+
+  if (offer.status === "active") {
+    return <OfferHero offer={offer} />;
+  }
+  return <TerminalState offer={offer} />;
+}

--- a/components/portal/OfferHero.tsx
+++ b/components/portal/OfferHero.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import Image from "next/image";
+import { useEffect, useState } from "react";
+import type { PublicOfferResponse } from "@/lib/types";
+
+interface Props {
+  offer: PublicOfferResponse;
+}
+
+function formatCurrency(amount: string | null | undefined): string {
+  if (!amount) return "—";
+  const num = Number(amount);
+  if (!Number.isFinite(num)) return "—";
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0
+  }).format(num);
+}
+
+interface Remaining {
+  expired: boolean;
+  days: number;
+  hours: number;
+  minutes: number;
+  seconds: number;
+}
+
+function computeRemaining(expiresAtIso: string): Remaining {
+  const now = Date.now();
+  const expiresAt = new Date(expiresAtIso).getTime();
+  const diffMs = expiresAt - now;
+  if (!Number.isFinite(expiresAt) || diffMs <= 0) {
+    return { expired: true, days: 0, hours: 0, minutes: 0, seconds: 0 };
+  }
+  const totalSeconds = Math.floor(diffMs / 1000);
+  const days = Math.floor(totalSeconds / 86400);
+  const hours = Math.floor((totalSeconds % 86400) / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  return { expired: false, days, hours, minutes, seconds };
+}
+
+function formatRemaining(r: Remaining): string {
+  if (r.expired) return "This offer has just expired. Refresh to update.";
+  if (r.days > 0) return `Offer expires in ${r.days}d ${r.hours}h ${r.minutes}m`;
+  if (r.hours > 0) return `Offer expires in ${r.hours}h ${r.minutes}m ${r.seconds}s`;
+  if (r.minutes > 0) return `Offer expires in ${r.minutes}m ${r.seconds}s`;
+  return `Offer expires in ${r.seconds}s`;
+}
+
+export function OfferHero({ offer }: Props) {
+  // SSR pass: compute once from props so initial markup matches hydration.
+  // Client tick: refresh every second.
+  const [remaining, setRemaining] = useState<Remaining>(() =>
+    computeRemaining(offer.expires_at)
+  );
+
+  useEffect(() => {
+    const tick = () => setRemaining(computeRemaining(offer.expires_at));
+    tick();
+    const id = window.setInterval(tick, 1000);
+    return () => window.clearInterval(id);
+  }, [offer.expires_at]);
+
+  const targetOffer = offer.offer?.target_offer ?? null;
+  // Phase 4.5.g foundation: backend doesn't yet expose property address on
+  // the public response. Property address surfaces with Layer 4 work in
+  // 4.5.h. Today the hero shows the headline + countdown only.
+  // (Per Rule 10.21: prompt asserted address in Layer 1; surfacing as drift
+  // because PublicOfferResponse contract has no address field.)
+
+  return (
+    <main
+      data-zona-gate="1"
+      className="flex min-h-screen flex-col bg-zona-off-white"
+    >
+      <header className="flex items-center justify-start px-6 py-6 md:px-12">
+        <div className="relative h-10 w-32">
+          <Image
+            src="/brand/zona-logo-primary-dark.png"
+            alt="Zona Desert"
+            fill
+            sizes="128px"
+            className="object-contain object-left"
+            priority
+          />
+        </div>
+      </header>
+
+      <section className="flex flex-1 items-center justify-center px-6 py-12 md:py-20">
+        <div className="w-full max-w-3xl space-y-10 text-center">
+          <div className="space-y-2">
+            <p
+              className="text-xs uppercase tracking-[0.3em] text-zona-purple-mid"
+              style={{ fontFamily: "var(--font-inter)", fontWeight: 500 }}
+            >
+              Your Offer From Zona Desert
+            </p>
+            <p
+              className="text-5xl text-zona-navy md:text-7xl"
+              style={{ fontFamily: "var(--font-sora)", fontWeight: 600 }}
+            >
+              {formatCurrency(targetOffer)}
+            </p>
+          </div>
+
+          <div
+            className="inline-flex items-center justify-center gap-2 rounded-full border border-zona-amber/40 bg-zona-amber/10 px-5 py-2"
+            role="status"
+            aria-live="polite"
+          >
+            <span
+              className="text-sm text-zona-navy md:text-base"
+              style={{ fontFamily: "var(--font-inter)", fontWeight: 500 }}
+            >
+              {formatRemaining(remaining)}
+            </span>
+          </div>
+
+          <div className="pt-8">
+            <a
+              href="#offer-details"
+              className="inline-flex flex-col items-center gap-1 text-zona-navy/60 transition hover:text-zona-purple-mid"
+              style={{ fontFamily: "var(--font-inter)", fontWeight: 500 }}
+              aria-label="Scroll for more details"
+            >
+              <span className="text-sm">More details below</span>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <polyline points="6 9 12 15 18 9" />
+              </svg>
+            </a>
+          </div>
+        </div>
+      </section>
+
+      <div id="offer-details" />
+    </main>
+  );
+}

--- a/components/portal/TerminalState.tsx
+++ b/components/portal/TerminalState.tsx
@@ -1,0 +1,134 @@
+import Image from "next/image";
+import type { PublicOfferResponse } from "@/lib/types";
+
+interface Props {
+  offer: PublicOfferResponse;
+}
+
+const ZONA_CONTACT_EMAIL = "hello@zonadesert.com";
+
+function formatDate(iso: string | null | undefined): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (!Number.isFinite(d.getTime())) return "";
+  return d.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric"
+  });
+}
+
+function formatCurrency(amount: string | null | undefined): string {
+  if (!amount) return "—";
+  const num = Number(amount);
+  if (!Number.isFinite(num)) return "—";
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0
+  }).format(num);
+}
+
+function buildCopy(offer: PublicOfferResponse): {
+  headline: string;
+  detail: string | null;
+  showContact: boolean;
+} {
+  switch (offer.status) {
+    case "expired":
+      return {
+        headline: "This offer has expired.",
+        detail: null,
+        showContact: true
+      };
+    case "accepted": {
+      const when = formatDate(offer.accepted_at);
+      return {
+        headline: "This offer has been accepted.",
+        detail: when ? `Accepted on ${when}. We'll be in touch.` : "We'll be in touch.",
+        showContact: false
+      };
+    }
+    case "countered": {
+      const when = formatDate(offer.countered_at);
+      const amount = formatCurrency(offer.counter_amount);
+      const datePart = when ? ` on ${when}` : "";
+      return {
+        headline: `Counter offer of ${amount} submitted${datePart}.`,
+        detail: "We'll be in touch.",
+        showContact: false
+      };
+    }
+    case "revoked":
+      return {
+        headline: "This offer is no longer available.",
+        detail: null,
+        showContact: true
+      };
+    default:
+      // Shouldn't reach here — page.tsx routes "active" to OfferHero.
+      return {
+        headline: "This offer is no longer available.",
+        detail: null,
+        showContact: true
+      };
+  }
+}
+
+export function TerminalState({ offer }: Props) {
+  const { headline, detail, showContact } = buildCopy(offer);
+
+  return (
+    <main
+      data-zona-gate="1"
+      className="flex min-h-screen flex-col bg-zona-off-white"
+    >
+      <header className="flex items-center justify-start px-6 py-6 md:px-12">
+        <div className="relative h-10 w-32">
+          <Image
+            src="/brand/zona-logo-primary-dark.png"
+            alt="Zona Desert"
+            fill
+            sizes="128px"
+            className="object-contain object-left"
+            priority
+          />
+        </div>
+      </header>
+
+      <section className="flex flex-1 items-center justify-center px-6 py-12 md:py-20">
+        <div className="w-full max-w-2xl space-y-6 text-center">
+          <h1
+            className="text-3xl text-zona-navy md:text-4xl"
+            style={{ fontFamily: "var(--font-sora)", fontWeight: 600 }}
+          >
+            {headline}
+          </h1>
+          {detail ? (
+            <p
+              className="text-base text-zona-navy/70 md:text-lg"
+              style={{ fontFamily: "var(--font-inter)" }}
+            >
+              {detail}
+            </p>
+          ) : null}
+          {showContact ? (
+            <p
+              className="text-base text-zona-navy/70 md:text-lg"
+              style={{ fontFamily: "var(--font-inter)" }}
+            >
+              Reach us at{" "}
+              <a
+                href={`mailto:${ZONA_CONTACT_EMAIL}`}
+                className="text-zona-purple-mid underline"
+              >
+                {ZONA_CONTACT_EMAIL}
+              </a>
+              .
+            </p>
+          ) : null}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/lib/publicApi.ts
+++ b/lib/publicApi.ts
@@ -1,6 +1,7 @@
 import {
   AgentIntakePayload,
   BuyerIntakePayload,
+  PublicOfferResponse,
   SellerLeadPayload,
   WholesalerIntakePayload
 } from "./types";
@@ -294,5 +295,25 @@ export async function createPublicWholesaler(formValues: WholesalerIntakePayload
     throw new PublicApiError(message, res.status);
   }
 
+  return res.json();
+}
+
+// ---------------------------------------------------------------------------
+// Public Offer Portal (Phase 4.5.g)
+//
+// Fetches GET /offers/{token} from the seller-facing public endpoint.
+// Server Component caller — cache: "no-store" because token state can
+// change between requests (JIT expiration at the backend). 404 returns
+// null so the caller can dispatch to Next.js notFound().
+// ---------------------------------------------------------------------------
+
+export async function fetchPublicOffer(token: string): Promise<PublicOfferResponse | null> {
+  const res = await fetch(`${API_BASE_URL}/offers/${encodeURIComponent(token)}`, {
+    cache: "no-store"
+  });
+  if (res.status === 404) return null;
+  if (!res.ok) {
+    throw new PublicApiError(`Failed to fetch offer: ${res.status}`, res.status);
+  }
   return res.json();
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -128,3 +128,58 @@ export interface WholesalerIntakePayload {
   dealsPerMonth?: string;
   notes?: string;
 }
+
+// ---------------------------------------------------------------------------
+// Public Offer Portal types (Phase 4.5.g)
+//
+// Mirror of backend Pydantic schemas in zona-admin at
+// apps/api/app/schemas/public_offer.py per Scar #24. Decimal columns on the
+// backend serialize as JSON strings via Pydantic V2 — typed `string | null`
+// on the wire. The portal UI handles string→number coercion at the
+// presentation boundary.
+// ---------------------------------------------------------------------------
+
+export type PublicOfferStatus = "active" | "expired" | "accepted" | "countered" | "revoked";
+
+export interface PublicOfferAmount {
+  target_offer: string;
+  bucket_scores: Array<Record<string, unknown>>;
+}
+
+export interface PublicPropertyFacts {
+  year_built: number | null;
+  bedrooms: number | null;
+  bathrooms: string | null;
+  sqft: number | null;
+  lot_size: string | null;
+  repair_level: string | null;
+}
+
+export interface PublicComp {
+  street_block: string;
+  sold_price: string | null;
+  sale_date: string | null;
+  beds: number | null;
+  baths: number | null;
+  sqft: number | null;
+  distance_miles: number | null;
+  sale_type: string | null;
+}
+
+export interface PublicExitStrategy {
+  arv_estimate_low: string | null;
+  arv_estimate_high: string | null;
+  estimated_rental_monthly: string | null;
+}
+
+export interface PublicOfferResponse {
+  status: PublicOfferStatus;
+  expires_at: string;
+  offer: PublicOfferAmount | null;
+  property_facts: PublicPropertyFacts | null;
+  comps: PublicComp[] | null;
+  exit_strategy: PublicExitStrategy | null;
+  accepted_at: string | null;
+  countered_at: string | null;
+  counter_amount: string | null;
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -10,9 +10,13 @@ const config: Config = {
     extend: {
       colors: {
         zona: {
-          purple: "#6366F1",
-          midnight: "#0F172A",
-          sand: "#F5F0E1"
+          "purple-deep": "#4A1988",
+          "purple-mid": "#7025B6",
+          purple: "#7025B6",
+          orange: "#FE642D",
+          amber: "#FEA91E",
+          navy: "#0E172A",
+          "off-white": "#F1F2EF"
         }
       }
     }


### PR DESCRIPTION
## Summary

**Phase 4.5.g — Public Portal Frontend Foundation.** First cross-repo PR. Eighth sub-phase of the Phase 4.5 wave. Builds the seller-facing offer portal at \`zonadesert.com/offer/{token}\` that consumes the 4.5.b API endpoint (\`GET /offers/{token}\`) shipped two weeks ago.

Per blueprint \`Zona_Desert_Offer_Delivery_Portal_v1.docx\` §5 (Public Offer Portal — Layer 1 Hero) + §3.1 (Token-Based Access). Layer 1 Hero only: large target offer amount in Sora SemiBold, expiration countdown timer (ticks every second). Mobile-first, brand-aligned. State-aware: active → \`OfferHero\` (client component for countdown); expired/accepted/countered/revoked → \`TerminalState\` (server component).

**Out of scope (deferred):** Layer 2-5 (4.5.h) / sticky action bar + Accept/Counter/Contact modals (4.5.i) / PDF generation (4.5.j).

## Blueprint Conformance

**Implements:** \`Zona_Desert_Offer_Delivery_Portal_v1.docx\` §3.1 (Token-Based Access) + §5 Layer 1 (Hero only)

**Sections addressed in this PR:**
- §3.1 — Token IS auth; server-side fetch via Next.js Server Component (no CORS, never cached, noindex/nofollow)
- §5 Layer 1 — Target offer amount + countdown timer; brand-styled (Sora SemiBold for headline, Inter Medium for countdown, Zona logo top-left)

**Sections explicitly NOT addressed (future PRs):**
- §5 Layer 2-5 (Why This Offer / Comps / Property Breakdown / Detailed Data) → 4.5.h
- §3.4 — Identity confirmation + Accept/Counter/Contact buttons → 4.5.i
- §11 — PDF Offer Package generation → 4.5.j

**Conformance delta:** Public Offer Portal moves from MISSING → STUB (Layer 1 active-state surface + 4 terminal-state shells shipped; Layers 2-5 + action bar still pending).

## Blueprint Conformance Verdict

**Blueprint implemented:** \`Zona_Desert_Offer_Delivery_Portal_v1.docx\` §3.1 + §5 Layer 1

**Sections truly addressed by this PR:**
1. §3.1 (Token-Based Access) — Server Component server-side fetch via existing \`lib/publicApi.ts\` API_BASE_URL helper; 404 from backend → Next.js \`notFound()\` → renders \`not-found.tsx\` shell; \`cache: "no-store"\` so JIT expiration at backend always surfaces; \`robots: noindex,nofollow,nocache\` on portal pages.
2. §5 Layer 1 (Hero) — Large target offer USD-formatted in Sora SemiBold navy; expiration countdown timer ticks every second in Inter Medium with brand amber accent; Zona logo top-left; chevron-down anchor placeholder for 4.5.h.

**Sections claimed but NOT fully addressed (scope-creep risk):** None — Layer 1 was the prompt's stated scope.

**Honest status after this PR:** STUB (active-state Layer 1 surface + 4 terminal states shipped; Layer 2-5 + action bar still pending).

**What still remains for CONFORMING status:**
- Layer 2 (Why This Offer narrative) → 4.5.h
- Layer 3 (Comparable Sales table) → 4.5.h
- Layer 4 (Property Breakdown) → 4.5.h
- Layer 5 (Detailed Data / Bucket Scores) → 4.5.h
- Sticky action bar + Accept/Counter/Contact modals (with identity verification UX) → 4.5.i
- PDF offer package generation + download → 4.5.j

## Spec Compliance Self-Review

**Prompt deliverables — line-by-line:**
- ✅ \`tailwind.config.ts\` EDIT — full Zona brand palette + brand-correct hex values shipped
- ✅ \`app/globals.css\` EDIT — 6 CSS custom properties appended (\`--color-purple-deep\`, \`--color-purple-mid\`, \`--color-orange\`, \`--color-amber\`, \`--color-navy\`, \`--color-off-white\`)
- ✅ \`lib/types.ts\` EDIT — 5 interfaces appended verbatim from backend Pydantic schemas: \`PublicOfferAmount\`, \`PublicPropertyFacts\`, \`PublicComp\`, \`PublicExitStrategy\`, \`PublicOfferResponse\` + \`PublicOfferStatus\` literal-union
- ✅ \`lib/publicApi.ts\` EDIT — \`fetchPublicOffer(token)\` appended; reuses existing \`API_BASE_URL\` private const; 404 → null; non-200/non-404 → \`PublicApiError\`
- ✅ \`app/offer/[token]/page.tsx\` NEW — Server Component; \`metadata\` exports \`robots: noindex,nofollow,nocache\`; dispatches active → OfferHero, terminal → TerminalState
- ✅ \`app/offer/[token]/not-found.tsx\` NEW — minimal brand-styled 404 shell; Zona logo icon + contact info
- ✅ \`components/portal/OfferHero.tsx\` NEW — \`"use client"\`; \`useState\`+\`useEffect\` countdown ticking every second; SSR-pass-safe initial computation; chevron-down anchor placeholder
- ✅ \`components/portal/TerminalState.tsx\` NEW — Server Component (no interactivity); 4 terminal-state copy variants; brand contact info constant

**⚠️ Rule 10.21 drifts (Scar #34 — disclosed explicitly):**

1. **⚠️ Property address NOT shown in Hero (backend schema gap).** The prompt's Layer 1 spec asserts "Property address below" the offer amount. However, the verbatim \`PublicOfferResponse\` schema in \`apps/api/app/schemas/public_offer.py\` (read pre-write per Scar #24) has NO address field — \`status\`, \`expires_at\`, \`offer\`, \`property_facts\`, \`comps\`, \`exit_strategy\`, \`accepted_at\`, \`countered_at\`, \`counter_amount\` only. \`PublicPropertyFacts\` carries \`year_built\`/\`bedrooms\`/\`bathrooms\`/\`sqft\`/\`lot_size\`/\`repair_level\` — no address. Per Rule 10.21, the smaller correct change is to omit the address line from Hero today and surface the gap rather than (a) extend the backend schema in this frontend-only PR per Rule 10.6 (no schema changes without explicit instruction) or (b) hardcode a placeholder string. The Hero shows the headline ("Your Offer From Zona Desert") + amount + countdown. Address surfaces with Layer 4 work in 4.5.h, which can either extend the backend response or denormalize at the projection helper layer (\`portal_view.py\`). Documented inline in \`OfferHero.tsx\` as a comment so the 4.5.h agent doesn't miss the gap.

2. **⚠️ \`zona.purple\` key PRESERVED in tailwind palette (existing-usage migration constraint).** The prompt asserts "REPLACE \`colors.zona\` block with the full Zona brand palette" implying \`zona.purple\` becomes \`zona.purple-mid\`. Pre-write \`grep -rn "zona-purple" app/ components/\` revealed 40+ usages across \`app/(site)/\`, \`app/(sell-submit)/\`, \`app/deal-pack/\`, \`components/Listing*.tsx\` — all of which are on the DO NOT TOUCH list. Renaming would break every one of these locked files. Per Rule 10.21, the smaller correct change is to KEEP the \`zona.purple\` key (which preserves all locked-file usages) AND fix its hex value from indigo \`#6366F1\` to brand-correct \`#7025B6\` (a hex correction inside the same key — improves rendering of locked pages without modifying their code) AND add the new full palette tokens (\`purple-deep\`, \`purple-mid\` as an alias of \`purple\`, \`orange\`, \`amber\`, \`navy\`, \`off-white\`) that the portal uses. \`zona.midnight\` + \`zona.sand\` had zero usages (verified via grep) so dropped safely. Net effect: locked files now render with brand-correct purple; portal uses the new full palette; no locked files touched. A future cleanup PR can complete the rename when the locked-file scope opens.

3. **⚠️ \`encodeURIComponent\` added to fetchPublicOffer URL construction (defensive correctness).** Prompt's literal: \`\`fetch(\`\${API_BASE_URL}/offers/\${token}\`, ...)\`\`. Per Rule 10.21, agent wrapped the token in \`encodeURIComponent\` because the public token is opaque user-controlled URL path input; if a malformed token ever contained URL-special chars (\`/\`, \`?\`, \`#\`), the literal would either path-fragment incorrectly OR upstream-resolve as a different route. Backend tokens are URL-safe base64 today (~43 chars) so this is suspenders-and-belt, but defensive correctness matches the established \`route.param\` discipline elsewhere in the codebase.

4. **⚠️ \`data-zona-gate="1"\` attribute added to portal page wrappers (small scope addition).** Not in the prompt's literal scope. Pre-write recon of \`app/globals.css\` showed an existing \`:has([data-zona-gate="1"])\` selector that suppresses the global cookie-consent banner on owner-gate routes. Portal pages are token-gated — showing the cookie banner on a focused offer view would be incongruent and would diminish the seller experience. One attribute per shell component matches the established pattern (used by \`/coming-soon\` and \`/__owner-access\`). Surfaced explicitly per Scar #34.

5. **⚠️ Logo asset path: \`/brand/zona-logo-primary-dark.png\` (Hero/Terminal) + \`/brand/zona-logo-icon.png\` (not-found).** Prompt said "Zona logo top-left (existing asset in \`public/\`; agent locates the file)." Pre-write recon found 5 logo assets under \`public/brand/\`. Chose \`zona-logo-primary-dark.png\` for the main Hero/Terminal shells (full wordmark + icon on dark navy mark — most prominent presentation for the offer surface) and the smaller \`zona-logo-icon.png\` for the 404 shell (icon-only matches the smaller content area).

**Scope additions (not in the prompt):** \`data-zona-gate="1"\` attribute (drift #4 above); \`encodeURIComponent\` wrap on token (drift #3 above).

**Scope cuts (in the prompt, not delivered):** Property address line in Hero (drift #1 above — backend schema gap, cannot be implemented in this frontend-only PR per Rule 10.6).

**Net result:** All 8 deliverable files shipped with 5 ⚠️ drift items surfaced above — 1 backend-schema gap (address), 1 brand-token-migration constraint (zona.purple key preserved), 1 defensive correctness (encodeURIComponent), 1 small scope addition (cookie-gate attribute), 1 logo-path agent judgment. All disclosures per Scar #34 anti-silent-drift discipline.

**STATUS:** DONE_WITH_CONCERNS

## Verified facts (pre-write recon)

- Backend \`PublicOfferResponse\` schema read verbatim from \`zona-admin\` at \`apps/api/app/schemas/public_offer.py\` (HEAD \`5c7e30a\`, PR #183) — 5 schemas + 1 literal-union mirrored field-by-field per Scar #24.
- Decimal columns serialize as JSON strings on the wire (Pydantic V2 default) — typed \`string | null\` on TS interfaces; UI handles string→number coercion at presentation layer (e.g., \`formatCurrency\` in Hero/Terminal).
- Existing \`API_BASE_URL\` in \`lib/publicApi.ts\` reused — supports 4 env-var aliases (\`NEXT_PUBLIC_API_URL\`/\`_BASE\`/\`_BASE_URL\`/\`_API\`) with trailing-slash strip and \`https://api.zonadesert.com\` default.
- Existing intake POST functions (\`createPublicBuyer\`, \`createPublicSeller\`, \`createPublicAgent\`, \`createPublicWholesaler\`) UNTOUCHED — additive contract preserved.
- Existing intake payload types in \`lib/types.ts\` UNTOUCHED — appended-only.
- Existing \`zona.purple\` Tailwind usages mapped: 40+ across \`app/(site)/\`, \`app/(sell-submit)/\`, \`app/deal-pack/\`, \`components/Listing*.tsx\` — all on DO NOT TOUCH list. Key preserved to avoid breakage.
- Server Component / Client Component boundary drawn correctly: \`page.tsx\` (Server, async, calls \`fetchPublicOffer\`) → \`OfferHero\` (Client, \`useState\`+\`useEffect\` for countdown tick) / \`TerminalState\` (Server, pure presentation).
- CORS not applicable (server-side fetch); \`cache: "no-store"\` so JIT expiration at backend always surfaces in next read.
- \`robots: noindex,nofollow,nocache\` on \`page.tsx\` metadata + \`not-found.tsx\` metadata — token-gated content must not be indexed.
- \`npm run lint\` ✔ No ESLint warnings or errors
- \`npm run build\` ✔ All routes compiled; \`/offer/[token]\` registered as dynamic (1.91 kB, 94.4 kB First Load JS).

## Test plan

- [x] \`npm run lint\` passes locally
- [x] \`npm run build\` passes locally; \`/offer/[token]\` route registered as dynamic
- [ ] Vercel preview deploy succeeds
- [ ] Preview URL \`/offer/test-token\` returns 404 (expected — no real tokens in production yet)
- [ ] CI lint+build job passes on GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)