### PR TITLE
feat(site): public offer portal Layers 2-5 + Hero address render (Phase 4.5.h.ui)

### DIFF
--- a/app/offer/[token]/page.tsx
+++ b/app/offer/[token]/page.tsx
@@ -2,6 +2,10 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { fetchPublicOffer } from "@/lib/publicApi";
 import { OfferHero } from "@/components/portal/OfferHero";
+import { LayerWhyZona } from "@/components/portal/LayerWhyZona";
+import { LayerCompEvidence } from "@/components/portal/LayerCompEvidence";
+import { LayerPropertyProfile } from "@/components/portal/LayerPropertyProfile";
+import { LayerScoreBreakdown } from "@/components/portal/LayerScoreBreakdown";
 import { TerminalState } from "@/components/portal/TerminalState";
 
 // Token-gated content must never be indexed. Robots noindex/nofollow per
@@ -22,13 +26,32 @@ export const metadata: Metadata = {
 // Server Component — token fetch happens server-side (no CORS, never
 // cached). Dispatch to the client OfferHero for the active-state
 // countdown timer; terminal states render via TerminalState (no
-// interactivity needed).
+// interactivity needed). Active state extends below the Hero with the
+// blueprint Layer 2-5 sections (4.5.h.ui).
 export default async function OfferPage({ params }: { params: { token: string } }) {
   const offer = await fetchPublicOffer(params.token);
   if (!offer) notFound();
 
   if (offer.status === "active") {
-    return <OfferHero offer={offer} />;
+    return (
+      <>
+        <OfferHero offer={offer} />
+        <div
+          data-zona-gate="1"
+          className="bg-zona-off-white pb-16"
+        >
+          <div className="mx-auto flex max-w-4xl flex-col gap-6 px-4 sm:px-6">
+            <LayerWhyZona />
+            <LayerCompEvidence comps={offer.comps} />
+            <LayerPropertyProfile
+              propertyFacts={offer.property_facts}
+              exitStrategy={offer.exit_strategy}
+            />
+            <LayerScoreBreakdown bucketScores={offer.offer?.bucket_scores ?? []} />
+          </div>
+        </div>
+      </>
+    );
   }
   return <TerminalState offer={offer} />;
 }

--- a/components/portal/LayerCompEvidence.tsx
+++ b/components/portal/LayerCompEvidence.tsx
@@ -1,0 +1,116 @@
+// Layer 3 (Comp Evidence) — comparable sales table.
+//
+// Per blueprint §5 Layer 3: street_block (sanitized at backend
+// portal_view.py boundary), sold_price, sale_date, distance, beds,
+// baths, sqft, sale_type. Empty/null comps render a placeholder card
+// rather than hiding the layer entirely (UX continuity).
+
+import type { PublicComp } from "@/lib/types";
+import { formatCurrency, formatDate, formatNumber } from "@/lib/portalFormatters";
+
+interface Props {
+  comps: PublicComp[] | null;
+}
+
+const EM_DASH = "—";
+
+function formatBaths(value: number | null): string {
+  if (value === null || value === undefined || !Number.isFinite(value)) {
+    return EM_DASH;
+  }
+  // Bathrooms allow half-bath increments; show 1 decimal when fractional.
+  return Number.isInteger(value) ? String(value) : value.toFixed(1);
+}
+
+function formatDistance(value: number | null): string {
+  if (value === null || value === undefined || !Number.isFinite(value)) {
+    return EM_DASH;
+  }
+  return `${value.toFixed(1)} mi`;
+}
+
+function formatSaleType(value: string | null): string {
+  if (!value) return EM_DASH;
+  // Replace underscores; title-case each word.
+  return value
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export function LayerCompEvidence({ comps }: Props) {
+  return (
+    <section
+      aria-labelledby="comp-evidence-title"
+      className="rounded-2xl border border-zona-purple-mid/15 bg-white p-6 shadow-sm md:p-8"
+    >
+      <h2
+        id="comp-evidence-title"
+        className="text-2xl text-zona-navy md:text-3xl"
+        style={{ fontFamily: "var(--font-sora)", fontWeight: 600 }}
+      >
+        Comparable Sales
+      </h2>
+      <p
+        className="mt-2 text-base text-zona-navy/70"
+        style={{ fontFamily: "var(--font-inter)" }}
+      >
+        Recent home sales near your property used to evaluate your offer.
+      </p>
+
+      {comps && comps.length > 0 ? (
+        <div className="mt-6 overflow-x-auto">
+          <table
+            className="w-full min-w-[720px] border-collapse text-left text-sm"
+            style={{ fontFamily: "var(--font-inter)" }}
+          >
+            <thead>
+              <tr className="border-b border-zona-navy/15 text-xs uppercase tracking-wider text-zona-navy/60">
+                <th className="py-3 pr-4 font-medium">Street Block</th>
+                <th className="py-3 pr-4 font-medium">Sold Price</th>
+                <th className="py-3 pr-4 font-medium">Sold Date</th>
+                <th className="py-3 pr-4 font-medium">Beds</th>
+                <th className="py-3 pr-4 font-medium">Baths</th>
+                <th className="py-3 pr-4 font-medium">Sqft</th>
+                <th className="py-3 pr-4 font-medium">Distance</th>
+                <th className="py-3 font-medium">Type</th>
+              </tr>
+            </thead>
+            <tbody>
+              {comps.map((comp, idx) => (
+                <tr
+                  key={`${comp.street_block}-${idx}`}
+                  className={
+                    idx % 2 === 0
+                      ? "bg-zona-off-white/40 text-zona-navy"
+                      : "text-zona-navy"
+                  }
+                >
+                  <td className="py-3 pr-4" style={{ fontWeight: 500 }}>
+                    {comp.street_block}
+                  </td>
+                  <td className="py-3 pr-4">{formatCurrency(comp.sold_price)}</td>
+                  <td className="py-3 pr-4">{formatDate(comp.sale_date)}</td>
+                  <td className="py-3 pr-4">
+                    {formatNumber(comp.beds)}
+                  </td>
+                  <td className="py-3 pr-4">{formatBaths(comp.baths)}</td>
+                  <td className="py-3 pr-4">{formatNumber(comp.sqft)}</td>
+                  <td className="py-3 pr-4">{formatDistance(comp.distance_miles)}</td>
+                  <td className="py-3">{formatSaleType(comp.sale_type)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <div
+          className="mt-6 rounded-xl border border-zona-amber/30 bg-zona-amber/5 p-5 text-base text-zona-navy/80"
+          style={{ fontFamily: "var(--font-inter)" }}
+        >
+          Comparable sales data is still being gathered. Your offer reflects
+          current market conditions in your area.
+        </div>
+      )}
+    </section>
+  );
+}

--- a/components/portal/LayerPropertyProfile.tsx
+++ b/components/portal/LayerPropertyProfile.tsx
@@ -1,0 +1,141 @@
+// Layer 4 (Property Profile) — combined property_facts + exit_strategy.
+//
+// Per backend schema docstring (apps/api/app/schemas/public_offer.py
+// lines 38-42), this layer spans BOTH:
+//   * PublicPropertyFacts (year_built, bedrooms, bathrooms, sqft,
+//     lot_size, repair_level)
+//   * PublicExitStrategy  (arv_estimate_low, arv_estimate_high,
+//     estimated_rental_monthly)
+//
+// Null handling:
+//   - propertyFacts == null AND exitStrategy == null → return null
+//     (parent dispatch hides the layer entirely)
+//   - propertyFacts == null → hide Layer 4 entirely (no facts to show)
+//   - exitStrategy == null → hide 4b only (Valuation Range subsection)
+//   - Individual field null → render em-dash (preserve grid layout)
+
+import type { PublicExitStrategy, PublicPropertyFacts } from "@/lib/types";
+import { formatCurrency, formatNumber } from "@/lib/portalFormatters";
+
+interface Props {
+  propertyFacts: PublicPropertyFacts | null;
+  exitStrategy: PublicExitStrategy | null;
+}
+
+const EM_DASH = "—";
+
+function formatBathrooms(value: string | null): string {
+  if (!value) return EM_DASH;
+  const num = Number(value);
+  if (!Number.isFinite(num)) return EM_DASH;
+  return Number.isInteger(num) ? String(num) : num.toFixed(1);
+}
+
+function formatLotSize(value: string | null): string {
+  if (!value) return EM_DASH;
+  const num = Number(value);
+  if (!Number.isFinite(num)) return EM_DASH;
+  return `${new Intl.NumberFormat("en-US").format(num)} sqft`;
+}
+
+function formatArvRange(
+  low: string | null,
+  high: string | null
+): string | null {
+  const lowFmt = formatCurrency(low);
+  const highFmt = formatCurrency(high);
+  if (lowFmt === EM_DASH && highFmt === EM_DASH) return null;
+  if (lowFmt === EM_DASH) return `Approx. ${highFmt}`;
+  if (highFmt === EM_DASH) return `Approx. ${lowFmt}`;
+  return `${lowFmt} – ${highFmt}`;
+}
+
+interface CellProps {
+  label: string;
+  value: string;
+}
+
+function FactCell({ label, value }: CellProps) {
+  return (
+    <div>
+      <p
+        className="text-xs uppercase tracking-wider text-zona-navy/60"
+        style={{ fontFamily: "var(--font-inter)", fontWeight: 500 }}
+      >
+        {label}
+      </p>
+      <p
+        className="mt-1 text-xl text-zona-navy"
+        style={{ fontFamily: "var(--font-sora)", fontWeight: 600 }}
+      >
+        {value}
+      </p>
+    </div>
+  );
+}
+
+export function LayerPropertyProfile({ propertyFacts, exitStrategy }: Props) {
+  if (!propertyFacts) return null;
+
+  const arvText = exitStrategy
+    ? formatArvRange(exitStrategy.arv_estimate_low, exitStrategy.arv_estimate_high)
+    : null;
+  const rentalText = exitStrategy
+    ? formatCurrency(exitStrategy.estimated_rental_monthly)
+    : EM_DASH;
+  const showValuationSection =
+    !!exitStrategy && (arvText !== null || rentalText !== EM_DASH);
+
+  return (
+    <section
+      aria-labelledby="property-profile-title"
+      className="rounded-2xl border border-zona-purple-mid/15 bg-white p-6 shadow-sm md:p-8"
+    >
+      <h2
+        id="property-profile-title"
+        className="text-2xl text-zona-navy md:text-3xl"
+        style={{ fontFamily: "var(--font-sora)", fontWeight: 600 }}
+      >
+        Your Property
+      </h2>
+
+      <div className="mt-6 grid grid-cols-2 gap-y-6 gap-x-4 md:grid-cols-6 md:gap-x-6">
+        <FactCell label="Year Built" value={formatNumber(propertyFacts.year_built)} />
+        <FactCell label="Bedrooms" value={formatNumber(propertyFacts.bedrooms)} />
+        <FactCell label="Bathrooms" value={formatBathrooms(propertyFacts.bathrooms)} />
+        <FactCell label="Square Feet" value={formatNumber(propertyFacts.sqft)} />
+        <FactCell label="Lot Size" value={formatLotSize(propertyFacts.lot_size)} />
+        <FactCell label="Condition" value={propertyFacts.repair_level ?? EM_DASH} />
+      </div>
+
+      {showValuationSection ? (
+        <div className="mt-8 border-t border-zona-navy/10 pt-6">
+          <h3
+            className="text-xs uppercase tracking-[0.3em] text-zona-purple-mid"
+            style={{ fontFamily: "var(--font-inter)", fontWeight: 500 }}
+          >
+            Valuation Range
+          </h3>
+          <div className="mt-3 flex flex-col gap-2 md:flex-row md:items-baseline md:gap-8">
+            {arvText ? (
+              <p
+                className="text-lg text-zona-navy md:text-xl"
+                style={{ fontFamily: "var(--font-sora)", fontWeight: 600 }}
+              >
+                ARV: {arvText}
+              </p>
+            ) : null}
+            {rentalText !== EM_DASH ? (
+              <p
+                className="text-lg text-zona-navy md:text-xl"
+                style={{ fontFamily: "var(--font-sora)", fontWeight: 600 }}
+              >
+                Monthly Rental: {rentalText} / mo
+              </p>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/components/portal/LayerScoreBreakdown.tsx
+++ b/components/portal/LayerScoreBreakdown.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+// Layer 5 (Score Breakdown) — expandable bucket score detail.
+//
+// Per backend schema docstring (apps/api/app/schemas/public_offer.py
+// lines 95-99), each bucket entry exposes category + score + max_points
+// only (no variables_breakdown — that detail is admin-internal).
+//
+// Empty bucket_scores → component returns null (Layer hidden entirely).
+// Score Breakdown is a detail-tier section; absence is fine without
+// a placeholder.
+
+import { useState } from "react";
+import type { PublicBucketScore } from "@/lib/types";
+
+interface Props {
+  bucketScores: PublicBucketScore[];
+}
+
+function titleCaseFromSnake(value: string): string {
+  return value
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function clampPercent(score: number, maxPoints: number): number {
+  if (!Number.isFinite(score) || !Number.isFinite(maxPoints) || maxPoints <= 0) {
+    return 0;
+  }
+  const pct = (score / maxPoints) * 100;
+  if (pct < 0) return 0;
+  if (pct > 100) return 100;
+  return pct;
+}
+
+export function LayerScoreBreakdown({ bucketScores }: Props) {
+  const [expanded, setExpanded] = useState(false);
+
+  if (!bucketScores || bucketScores.length === 0) return null;
+
+  return (
+    <section
+      aria-labelledby="score-breakdown-title"
+      className="rounded-2xl border border-zona-purple-mid/15 bg-white shadow-sm"
+    >
+      <button
+        type="button"
+        onClick={() => setExpanded((prev) => !prev)}
+        aria-expanded={expanded}
+        aria-controls="score-breakdown-panel"
+        className="flex w-full items-center justify-between gap-4 px-6 py-5 text-left transition hover:bg-zona-off-white/40 md:px-8"
+      >
+        <div>
+          <h2
+            id="score-breakdown-title"
+            className="text-2xl text-zona-navy md:text-3xl"
+            style={{ fontFamily: "var(--font-sora)", fontWeight: 600 }}
+          >
+            Score Breakdown
+          </h2>
+          <p
+            className="mt-1 text-sm text-zona-navy/70"
+            style={{ fontFamily: "var(--font-inter)" }}
+          >
+            How your offer was calculated
+          </p>
+        </div>
+        <span
+          className={`flex-shrink-0 text-zona-purple-mid transition-transform duration-200 ${
+            expanded ? "rotate-180" : ""
+          }`}
+          aria-hidden="true"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <polyline points="6 9 12 15 18 9" />
+          </svg>
+        </span>
+      </button>
+
+      {expanded ? (
+        <div
+          id="score-breakdown-panel"
+          className="border-t border-zona-navy/10 px-6 pb-6 pt-5 md:px-8"
+        >
+          <ul className="space-y-5">
+            {bucketScores.map((bucket) => {
+              const pct = clampPercent(bucket.score, bucket.max_points);
+              return (
+                <li key={bucket.category}>
+                  <div className="flex items-baseline justify-between gap-4">
+                    <span
+                      className="text-base text-zona-navy"
+                      style={{ fontFamily: "var(--font-inter)", fontWeight: 500 }}
+                    >
+                      {titleCaseFromSnake(bucket.category)}
+                    </span>
+                    <span
+                      className="text-sm text-zona-navy/70"
+                      style={{ fontFamily: "var(--font-inter)" }}
+                    >
+                      {bucket.score} / {bucket.max_points}
+                    </span>
+                  </div>
+                  <div
+                    className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-zona-navy/10"
+                    role="presentation"
+                  >
+                    <div
+                      className="h-full rounded-full bg-zona-purple-mid"
+                      style={{ width: `${pct}%` }}
+                    />
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/components/portal/LayerWhyZona.tsx
+++ b/components/portal/LayerWhyZona.tsx
@@ -1,0 +1,65 @@
+// Layer 2 (Confidence Wrap) — MVP templated trust block.
+//
+// Per backend schema docstring at apps/api/app/schemas/public_offer.py
+// line 47, engine narrative is explicitly out of scope for this layer
+// today. When backend exposes a data-driven "Why this offer" narrative
+// in a future PR, swap this templated copy for the dynamic version.
+
+const BULLETS = [
+  "Fair, data-backed offers based on comparable sales in your neighborhood",
+  "Close in as little as 7 days — or on your timeline",
+  "No fees, no commissions, no closing costs charged to you",
+  "No inspections, repairs, or financing contingencies required",
+  "Real people, real answers — reach us anytime by phone or text"
+];
+
+export function LayerWhyZona() {
+  return (
+    <section
+      aria-labelledby="why-zona-title"
+      className="rounded-2xl border border-zona-purple-mid/15 bg-white p-6 shadow-sm md:p-8"
+    >
+      <h2
+        id="why-zona-title"
+        className="text-xs uppercase tracking-[0.3em] text-zona-purple-mid"
+        style={{ fontFamily: "var(--font-inter)", fontWeight: 500 }}
+      >
+        Why Zona Desert
+      </h2>
+      <p
+        className="mt-2 text-2xl text-zona-navy md:text-3xl"
+        style={{ fontFamily: "var(--font-sora)", fontWeight: 600 }}
+      >
+        A fair offer. A clean close. No surprises.
+      </p>
+
+      <ul className="mt-6 space-y-3">
+        {BULLETS.map((bullet) => (
+          <li key={bullet} className="flex items-start gap-3">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="mt-1 flex-shrink-0 text-zona-amber"
+              aria-hidden="true"
+            >
+              <polyline points="20 6 9 17 4 12" />
+            </svg>
+            <span
+              className="text-base text-zona-navy/85"
+              style={{ fontFamily: "var(--font-inter)", fontWeight: 500 }}
+            >
+              {bullet}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/components/portal/OfferHero.tsx
+++ b/components/portal/OfferHero.tsx
@@ -3,20 +3,10 @@
 import Image from "next/image";
 import { useEffect, useState } from "react";
 import type { PublicOfferResponse } from "@/lib/types";
+import { formatCurrency } from "@/lib/portalFormatters";
 
 interface Props {
   offer: PublicOfferResponse;
-}
-
-function formatCurrency(amount: string | null | undefined): string {
-  if (!amount) return "—";
-  const num = Number(amount);
-  if (!Number.isFinite(num)) return "—";
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: "USD",
-    maximumFractionDigits: 0
-  }).format(num);
 }
 
 interface Remaining {
@@ -65,11 +55,6 @@ export function OfferHero({ offer }: Props) {
   }, [offer.expires_at]);
 
   const targetOffer = offer.offer?.target_offer ?? null;
-  // Phase 4.5.g foundation: backend doesn't yet expose property address on
-  // the public response. Property address surfaces with Layer 4 work in
-  // 4.5.h. Today the hero shows the headline + countdown only.
-  // (Per Rule 10.21: prompt asserted address in Layer 1; surfacing as drift
-  // because PublicOfferResponse contract has no address field.)
 
   return (
     <main
@@ -103,6 +88,12 @@ export function OfferHero({ offer }: Props) {
               style={{ fontFamily: "var(--font-sora)", fontWeight: 600 }}
             >
               {formatCurrency(targetOffer)}
+            </p>
+            <p
+              className="pt-2 text-lg text-zona-navy md:text-2xl"
+              style={{ fontFamily: "var(--font-sora)", fontWeight: 600 }}
+            >
+              {offer.property_address}
             </p>
           </div>
 

--- a/lib/portalFormatters.ts
+++ b/lib/portalFormatters.ts
@@ -1,0 +1,39 @@
+// Shared formatter helpers for the public offer portal (Phase 4.5.h.ui).
+// Backend Decimal columns serialize as JSON strings via Pydantic V2; UI
+// coerces at the presentation boundary. All helpers degrade to em-dash
+// on null / non-finite / unparseable input.
+
+const EM_DASH = "—";
+
+export function formatCurrency(value: string | null | undefined): string {
+  if (value === null || value === undefined || value === "") return EM_DASH;
+  const num = Number(value);
+  if (!Number.isFinite(num)) return EM_DASH;
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0
+  }).format(num);
+}
+
+export function formatNumber(
+  value: number | null | undefined,
+  suffix?: string
+): string {
+  if (value === null || value === undefined || !Number.isFinite(value)) {
+    return EM_DASH;
+  }
+  const formatted = new Intl.NumberFormat("en-US").format(value);
+  return suffix ? `${formatted}${suffix}` : formatted;
+}
+
+export function formatDate(value: string | null | undefined): string {
+  if (!value) return EM_DASH;
+  const d = new Date(value);
+  if (!Number.isFinite(d.getTime())) return EM_DASH;
+  return d.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric"
+  });
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -141,9 +141,15 @@ export interface WholesalerIntakePayload {
 
 export type PublicOfferStatus = "active" | "expired" | "accepted" | "countered" | "revoked";
 
+export interface PublicBucketScore {
+  category: string;
+  score: number;
+  max_points: number;
+}
+
 export interface PublicOfferAmount {
   target_offer: string;
-  bucket_scores: Array<Record<string, unknown>>;
+  bucket_scores: PublicBucketScore[];
 }
 
 export interface PublicPropertyFacts {
@@ -175,6 +181,7 @@ export interface PublicExitStrategy {
 export interface PublicOfferResponse {
   status: PublicOfferStatus;
   expires_at: string;
+  property_address: string;
   offer: PublicOfferAmount | null;
   property_facts: PublicPropertyFacts | null;
   comps: PublicComp[] | null;


### PR DESCRIPTION
## Summary

Closes the engine-visibility cycle on the seller-facing portal. Active state at `zonadesert.com/offer/{token}` now renders blueprint `Zona_Desert_Offer_Delivery_Portal_v1.docx` §5 Layers 1-5; PR #12 Drift #1 (missing `property_address` in Hero) resolved with the field shipped in zona-admin PR #184 (4.5.h.api).

**8 files (3 EDIT + 5 NEW):**
- `lib/types.ts` — append `property_address: string` (REQUIRED) + tighten `bucket_scores` type
- `lib/portalFormatters.ts` — shared `formatCurrency`/`formatNumber`/`formatDate` helpers
- `components/portal/OfferHero.tsx` — render `property_address` + retrofit to shared formatter
- `components/portal/LayerWhyZona.tsx` — Layer 2 templated trust block (Server Component)
- `components/portal/LayerCompEvidence.tsx` — Layer 3 comp table (Server Component, mobile scrollable)
- `components/portal/LayerPropertyProfile.tsx` — Layer 4 combined property_facts + exit_strategy (Server Component)
- `components/portal/LayerScoreBreakdown.tsx` — Layer 5 expandable bucket scores (Client Component)
- `app/offer/[token]/page.tsx` — wire 4 new layers below Hero in max-w-4xl reading-width container

ZERO new deps; ZERO backend; ZERO migrations; ZERO settings; ZERO AI; ZERO Sentry spans.

## Spec Compliance Self-Review

**Prompt deliverables — line-by-line:**
- ✅ `lib/types.ts` — appended `property_address: string` after `expires_at`, REQUIRED (no `?`, no `| null`); tightened `bucket_scores` to `PublicBucketScore[]` per backend docstring; existing 4 sub-interfaces structurally untouched
- ✅ `components/portal/OfferHero.tsx` — added property address line below target offer (Sora SemiBold, navy); retrofitted formatCurrency to shared `lib/portalFormatters.ts`; existing useState+useEffect countdown logic, Zona logo, chevron-down anchor UNCHANGED; removed PR #12 Drift #1 placeholder comment
- ✅ `components/portal/LayerWhyZona.tsx` — Server Component with templated trust block (5 bullets via `.map`, brand-amber check icon inline SVG, white card + brand-purple-mid tinted border)
- ✅ `components/portal/LayerCompEvidence.tsx` — Server Component, 8-column native HTML table, mobile horizontally scrollable (`overflow-x-auto`), zebra striping, empty/null comps → brand-styled placeholder card
- ✅ `components/portal/LayerPropertyProfile.tsx` — Server Component combining property_facts (4a, responsive 2-col mobile / 6-col desktop grid) + exit_strategy (4b ARV range + Monthly Rental); null handling per design (both null → null return; facts null → entire layer hidden via parent dispatch; exit_strategy null → 4b hidden only; one-bound-null on ARV → "Approx." prefix)
- ✅ `components/portal/LayerScoreBreakdown.tsx` — Client Component (`"use client"`), useState toggle, collapsed by default, chevron rotation via CSS transform, progress bars in brand-purple-mid; empty bucket_scores → component returns null
- ✅ `lib/portalFormatters.ts` — three pure functions (formatCurrency / formatNumber / formatDate); all em-dash on null/non-finite/unparseable
- ✅ `app/offer/[token]/page.tsx` — active state wraps 4 new Layers in `max-w-4xl mx-auto px-4 sm:px-6` container below Hero (Hero stays full-width); terminal state dispatch UNCHANGED

**Verified facts:**
- Read `apps/api/app/schemas/public_offer.py` lines 30-65 verbatim per Scar #24 — Layer 1-5 mapping confirmed; Layer 4 spans property_facts AND exit_strategy (NOT facts alone); Layer 2 engine narrative explicitly out of scope; bucket_scores entry shape `{category, score, max_points}` confirmed
- `property_address: str` is REQUIRED (no Optional) on backend per `PublicOfferResponse` line 208 + module docstring lines 185-192 — TS type matches as `string` (no null)
- `npm run lint` — clean, no ESLint warnings or errors
- `npm run build` — green; `/offer/[token]` route built at 2.57 kB First Load JS
- All 21 routes successfully generated; build trace clean
- Existing TerminalState.tsx UNTOUCHED per "DO NOT TOUCH" scope (still has its own inlined formatters; consolidation deferred to future PR if/when terminal states need new format types)
- Existing `lib/publicApi.ts` UNTOUCHED — no changes needed; `fetchPublicOffer` returns the new field automatically via TS structural typing
- `bucket_scores` TS tightening from `Array<Record<string, unknown>>` to `PublicBucketScore[]` is Scar #27 additive type refinement; new shape is a strict subset of the prior any-record shape, no downstream consumers break

**Scope additions (not in the prompt):** none.

**Scope cuts (in the prompt, not delivered):** none.

**Net result:** all 8 deliverables shipped clean, no Rule 10.21 drifts surfaced.

**STATUS:** DONE

## Blueprint Conformance

**Implements:** `Zona_Desert_Offer_Delivery_Portal_v1.docx` §5 (Page Sections / Layered Disclosure) Layers 1-5 (active state)

**Sections addressed in this PR:**
- §5 Layer 1 (Headline): `property_address` line below target offer in Hero (resolves PR #12 Drift #1)
- §5 Layer 2 (Confidence Wrap): MVP templated "Why Zona Desert" trust block — engine narrative explicitly out of scope per backend docstring
- §5 Layer 3 (Comp Evidence): comparable sales table consuming `comps: PublicComp[]` with full street_block sanitization upheld at backend boundary
- §5 Layer 4 (Property Profile): combined property_facts grid + exit_strategy ARV/rental valuation range
- §5 Layer 5 (Score Breakdown): expandable bucket_scores list with progress bars

**Sections explicitly NOT addressed (future PRs):**
- §3.5 Sticky action bar (Accept / Counter / Contact buttons) — Phase 4.5.i
- §11 PDF Offer Package generation — Phase 4.5.j
- §5 Layer 2 data-driven engine narrative (when backend exposes it) — future PR
- §5 Layer 3 comp map / photo galleries — future enhancement

**Conformance delta:** Public portal active state moves from STUB (Hero + countdown only post-PR #12) to SCAFFOLDING toward CONFORMING for §5 Layered Disclosure (5 of 5 active-state layers now render; sticky action bar + PDF still pending for full §3.5 + §11 conformance).

## Blueprint Conformance Verdict

**Blueprint implemented:** `Zona_Desert_Offer_Delivery_Portal_v1.docx` §5 (Layered Disclosure)

**Sections truly addressed by this PR:**
1. §5 Layer 1: property_address rendered in Hero
2. §5 Layer 2: templated MVP trust block (engine narrative deferred)
3. §5 Layer 3: comp table with full 8-column shape + empty/null placeholder
4. §5 Layer 4: property_facts grid + exit_strategy valuation subsection (combined per blueprint)
5. §5 Layer 5: expandable bucket score breakdown

**Sections claimed but NOT fully addressed (scope-creep risk):**
- §5 Layer 2 engine narrative — explicitly templated (out of scope per backend docstring); future PR upgrades when backend ships dynamic narrative

**Honest status after this PR:** SCAFFOLDING (active-state Layered Disclosure complete; sticky action bar + PDF still pending for full Phase 4.5 closure)

**What still remains for CONFORMING status:**
- Phase 4.5.i — sticky action bar (Accept / Counter / Contact wired to public action endpoints from 4.5.c)
- Phase 4.5.j — PDF offer package generation per blueprint §11
- Future enhancement — Layer 2 data-driven engine narrative when backend supports it

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` green; all 21 routes built
- [x] `/offer/[token]` route compiled at 2.57 kB First Load JS
- [x] TS types match backend Pydantic shape verbatim (property_address required; bucket_scores tightened)
- [x] All null-handling boundary cases honored per §18.3 (comps empty → placeholder; bucket_scores empty → hidden; exit_strategy null → hide 4b only; property_facts null → hide Layer 4; field-level nulls → em-dash)
- [ ] Vercel preview deploy succeeds (CI will verify)
- [ ] Visual verification on live preview: Hero shows property address; Layer 2 trust block renders; Layer 3 comp table renders or placeholder; Layer 4 grid + valuation range render; Layer 5 expand/collapse works

🤖 Generated with [Claude Code](https://claude.com/claude-code)