### PR TITLE
feat(site): sticky action bar + Accept/Counter/Contact modals (Phase 4.5.i)

### DIFF
--- a/app/offer/[token]/page.tsx
+++ b/app/offer/[token]/page.tsx
@@ -6,6 +6,7 @@ import { LayerWhyZona } from "@/components/portal/LayerWhyZona";
 import { LayerCompEvidence } from "@/components/portal/LayerCompEvidence";
 import { LayerPropertyProfile } from "@/components/portal/LayerPropertyProfile";
 import { LayerScoreBreakdown } from "@/components/portal/LayerScoreBreakdown";
+import { StickyActionBar } from "@/components/portal/StickyActionBar";
 import { TerminalState } from "@/components/portal/TerminalState";
 
 // Token-gated content must never be indexed. Robots noindex/nofollow per
@@ -38,7 +39,7 @@ export default async function OfferPage({ params }: { params: { token: string } 
         <OfferHero offer={offer} />
         <div
           data-zona-gate="1"
-          className="bg-zona-off-white pb-16"
+          className="bg-zona-off-white pb-32 sm:pb-24"
         >
           <div className="mx-auto flex max-w-4xl flex-col gap-6 px-4 sm:px-6">
             <LayerWhyZona />
@@ -50,6 +51,10 @@ export default async function OfferPage({ params }: { params: { token: string } 
             <LayerScoreBreakdown bucketScores={offer.offer?.bucket_scores ?? []} />
           </div>
         </div>
+        <StickyActionBar
+          token={params.token}
+          targetOffer={offer.offer?.target_offer ?? "0"}
+        />
       </>
     );
   }

--- a/components/portal/AcceptOfferModal.tsx
+++ b/components/portal/AcceptOfferModal.tsx
@@ -1,0 +1,251 @@
+"use client";
+
+// AcceptOfferModal (Phase 4.5.i) — 2-phase confirm → result modal that
+// wires the seller-portal Accept action into POST /offers/{token}/accept.
+//
+// On success, the modal transitions to a result view; closing triggers
+// router.refresh() so the Server Component re-fetches the (now terminal)
+// offer state and TerminalState renders. Backend identity failure (400)
+// surfaces inline; phone clears, name preserved for retry per UX spec.
+
+import { useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { acceptOffer, PublicApiError } from "@/lib/publicApi";
+import { formatCurrency } from "@/lib/portalFormatters";
+import { IdentityVerificationFields } from "./IdentityVerificationFields";
+
+interface Props {
+  open: boolean;
+  token: string;
+  targetOffer: string;
+  onClose: () => void;
+}
+
+type Phase = "confirm" | "result";
+
+interface SuccessState {
+  acceptedAt: string;
+  message: string;
+}
+
+export function AcceptOfferModal({ open, token, targetOffer, onClose }: Props) {
+  const router = useRouter();
+  const [phase, setPhase] = useState<Phase>("confirm");
+  const [name, setName] = useState("");
+  const [phoneLast4, setPhoneLast4] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<SuccessState | null>(null);
+
+  // Reset state when the modal opens; preserves a clean slate per re-open.
+  useEffect(() => {
+    if (!open) return;
+    setPhase("confirm");
+    setName("");
+    setPhoneLast4("");
+    setSubmitting(false);
+    setSubmitError(null);
+    setSuccess(null);
+  }, [open]);
+
+  const handleClose = useCallback(() => {
+    if (submitting) return;
+    const wasSuccess = phase === "result";
+    onClose();
+    if (wasSuccess) {
+      // router.refresh() re-fetches the Server Component data; TerminalState
+      // renders for the new accepted status.
+      router.refresh();
+    }
+  }, [submitting, phase, onClose, router]);
+
+  // ESC + outside-click handlers. Skipped while submitting so the user
+  // can't accidentally cancel mid-request.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") handleClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, handleClose]);
+
+  if (!open) return null;
+
+  const clientNameError =
+    submitError && !name.trim() ? "Please enter your full name." : undefined;
+  const clientPhoneError =
+    submitError && phoneLast4.length < 4
+      ? "Please enter the last 4 digits of your phone."
+      : undefined;
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (submitting) return;
+    setSubmitError(null);
+
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      setSubmitError("Please enter your full name.");
+      return;
+    }
+    if (phoneLast4.length < 4) {
+      setSubmitError("Please enter the last 4 digits of your phone.");
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const result = await acceptOffer(token, {
+        identity_check_name: trimmedName,
+        identity_check_phone_last4: phoneLast4
+      });
+      setSuccess({ acceptedAt: result.accepted_at, message: result.message });
+      setPhase("result");
+    } catch (err) {
+      const message =
+        err instanceof PublicApiError
+          ? err.message
+          : "Connection issue — please retry.";
+      setSubmitError(message);
+      // Clear phone for retry, preserve name (UX spec).
+      setPhoneLast4("");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div
+      data-zona-gate="1"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-zona-navy/60 px-4 py-6"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="accept-modal-title"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) handleClose();
+      }}
+    >
+      <div className="w-full max-w-md overflow-hidden rounded-2xl bg-zona-off-white shadow-2xl">
+        {phase === "confirm" ? (
+          <form onSubmit={handleSubmit}>
+            <div className="space-y-5 px-6 py-6 md:px-8 md:py-7">
+              <div className="space-y-2">
+                <h2
+                  id="accept-modal-title"
+                  className="text-2xl text-zona-navy md:text-3xl"
+                  style={{ fontFamily: "var(--font-sora)", fontWeight: 600 }}
+                >
+                  Accept Your Offer
+                </h2>
+                <p
+                  className="text-base text-zona-navy/80"
+                  style={{ fontFamily: "var(--font-inter)" }}
+                >
+                  By accepting, you agree to sell your property to Zona Desert at{" "}
+                  <span style={{ fontWeight: 600 }}>{formatCurrency(targetOffer)}</span>
+                  . We&apos;ll begin the closing process within 1 business day.
+                </p>
+              </div>
+
+              <IdentityVerificationFields
+                name={name}
+                phoneLast4={phoneLast4}
+                onChange={({ name: n, phoneLast4: p }) => {
+                  setName(n);
+                  setPhoneLast4(p);
+                }}
+                nameError={clientNameError}
+                phoneError={clientPhoneError}
+                disabled={submitting}
+              />
+
+              {submitError && !clientNameError && !clientPhoneError ? (
+                <div
+                  role="alert"
+                  className="rounded-lg border border-zona-orange/40 bg-zona-orange/10 px-4 py-3"
+                >
+                  <p
+                    className="text-sm text-zona-navy"
+                    style={{ fontFamily: "var(--font-inter)" }}
+                  >
+                    {submitError}
+                  </p>
+                </div>
+              ) : null}
+            </div>
+
+            <div className="flex items-center justify-end gap-3 border-t border-zona-navy/10 bg-white px-6 py-4 md:px-8">
+              <button
+                type="button"
+                onClick={handleClose}
+                disabled={submitting}
+                className="rounded-lg px-4 py-2 text-base text-zona-navy/70 transition hover:text-zona-navy disabled:opacity-60"
+                style={{ fontFamily: "var(--font-inter)", fontWeight: 500 }}
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={submitting}
+                className="rounded-lg bg-zona-purple-mid px-5 py-2 text-base text-white shadow-sm transition hover:bg-zona-purple-deep disabled:opacity-60"
+                style={{ fontFamily: "var(--font-sora)", fontWeight: 600 }}
+              >
+                {submitting ? "Submitting…" : "Accept Offer"}
+              </button>
+            </div>
+          </form>
+        ) : (
+          <div>
+            <div className="space-y-3 px-6 py-6 md:px-8 md:py-7">
+              <h2
+                id="accept-modal-title"
+                className="text-2xl text-zona-navy md:text-3xl"
+                style={{ fontFamily: "var(--font-sora)", fontWeight: 600 }}
+              >
+                Offer Accepted
+              </h2>
+              <p
+                className="text-base text-zona-navy/85"
+                style={{ fontFamily: "var(--font-inter)" }}
+              >
+                {success?.message ??
+                  "Offer accepted. Our team will reach out shortly with next steps."}
+              </p>
+              {success?.acceptedAt ? (
+                <p
+                  className="text-sm text-zona-navy/60"
+                  style={{ fontFamily: "var(--font-inter)" }}
+                >
+                  Accepted {formatAcceptedAt(success.acceptedAt)}
+                </p>
+              ) : null}
+            </div>
+            <div className="flex items-center justify-end gap-3 border-t border-zona-navy/10 bg-white px-6 py-4 md:px-8">
+              <button
+                type="button"
+                onClick={handleClose}
+                className="rounded-lg bg-zona-purple-mid px-5 py-2 text-base text-white shadow-sm transition hover:bg-zona-purple-deep"
+                style={{ fontFamily: "var(--font-sora)", fontWeight: 600 }}
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function formatAcceptedAt(iso: string): string {
+  const d = new Date(iso);
+  if (!Number.isFinite(d.getTime())) return "";
+  return d.toLocaleString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit"
+  });
+}

--- a/components/portal/ContactModal.tsx
+++ b/components/portal/ContactModal.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+// ContactModal (Phase 4.5.i) — 2-phase confirm → result modal that wires
+// the seller-portal Contact action into POST /offers/{token}/contact.
+//
+// Friction-light by design: NO identity verification (backend ContactRequest
+// accepts an empty body per blueprint §3.5). NO state transition either —
+// closing this modal does NOT trigger router.refresh() because the token
+// remains in its current state and the action bar stays visible.
+
+import { useCallback, useEffect, useState } from "react";
+import { contactZona, PublicApiError } from "@/lib/publicApi";
+
+interface Props {
+  open: boolean;
+  token: string;
+  onClose: () => void;
+}
+
+type Phase = "confirm" | "result";
+
+interface SuccessState {
+  zonaPhone: string;
+}
+
+export function ContactModal({ open, token, onClose }: Props) {
+  const [phase, setPhase] = useState<Phase>("confirm");
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<SuccessState | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setPhase("confirm");
+    setSubmitting(false);
+    setSubmitError(null);
+    setSuccess(null);
+  }, [open]);
+
+  const handleClose = useCallback(() => {
+    if (submitting) return;
+    onClose();
+    // No router.refresh() — Contact does not change token state.
+  }, [submitting, onClose]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") handleClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, handleClose]);
+
+  if (!open) return null;
+
+  async function handleSubmit() {
+    if (submitting) return;
+    setSubmitError(null);
+    setSubmitting(true);
+    try {
+      const result = await contactZona(token);
+      setSuccess({ zonaPhone: result.zona_phone });
+      setPhase("result");
+    } catch (err) {
+      const message =
+        err instanceof PublicApiError
+          ? err.message
+          : "Connection issue — please retry.";
+      setSubmitError(message);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div
+      data-zona-gate="1"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-zona-navy/60 px-4 py-6"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="contact-modal-title"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) handleClose();
+      }}
+    >
+      <div className="w-full max-w-md overflow-hidden rounded-2xl bg-zona-off-white shadow-2xl">
+        {phase === "confirm" ? (
+          <div>
+            <div className="space-y-3 px-6 py-6 md:px-8 md:py-7">
+              <h2
+                id="contact-modal-title"
+                className="text-2xl text-zona-navy md:text-3xl"
+                style={{ fontFamily: "var(--font-sora)", fontWeight: 600 }}
+              >
+                Get in Touch
+              </h2>
+              <p
+                className="text-base text-zona-navy/85"
+                style={{ fontFamily: "var(--font-inter)" }}
+              >
+                Have questions or want to discuss your offer? Click below and a
+                Zona team member will reach out to you within 1 business hour
+                during business hours.
+              </p>
+
+              {submitError ? (
+                <div
+                  role="alert"
+                  className="rounded-lg border border-zona-orange/40 bg-zona-orange/10 px-4 py-3"
+                >
+                  <p
+                    className="text-sm text-zona-navy"
+                    style={{ fontFamily: "var(--font-inter)" }}
+                  >
+                    {submitError}
+                  </p>
+                </div>
+              ) : null}
+            </div>
+            <div className="flex items-center justify-end gap-3 border-t border-zona-navy/10 bg-white px-6 py-4 md:px-8">
+              <button
+                type="button"
+                onClick={handleClose}
+                disabled={submitting}
+                className="rounded-lg px-4 py-2 text-base text-zona-navy/70 transition hover:text-zona-navy disabled:opacity-60"
+                style={{ fontFamily: "var(--font-inter)", fontWeight: 500 }}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleSubmit}
+                disabled={submitting}
+                className="rounded-lg border-2 border-zona-amber bg-white px-5 py-2 text-base text-zona-navy shadow-sm transition hover:bg-zona-amber/10 disabled:opacity-60"
+                style={{ fontFamily: "var(--font-sora)", fontWeight: 600 }}
+              >
+                {submitting ? "Submitting…" : "Request Contact"}
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div>
+            <div className="space-y-3 px-6 py-6 md:px-8 md:py-7">
+              <h2
+                id="contact-modal-title"
+                className="text-2xl text-zona-navy md:text-3xl"
+                style={{ fontFamily: "var(--font-sora)", fontWeight: 600 }}
+              >
+                We&apos;ll Reach Out Shortly
+              </h2>
+              <p
+                className="text-base text-zona-navy/85"
+                style={{ fontFamily: "var(--font-inter)" }}
+              >
+                We&apos;ve received your request. Expect a call or text within 1
+                business hour.
+              </p>
+              {success?.zonaPhone ? (
+                <p
+                  className="text-sm text-zona-navy/70"
+                  style={{ fontFamily: "var(--font-inter)" }}
+                >
+                  Or call us directly:{" "}
+                  <a
+                    href={`tel:${success.zonaPhone.replace(/[^\d+]/g, "")}`}
+                    className="text-zona-purple-mid underline"
+                    style={{ fontWeight: 500 }}
+                  >
+                    {success.zonaPhone}
+                  </a>
+                </p>
+              ) : null}
+            </div>
+            <div className="flex items-center justify-end gap-3 border-t border-zona-navy/10 bg-white px-6 py-4 md:px-8">
+              <button
+                type="button"
+                onClick={handleClose}
+                className="rounded-lg bg-zona-purple-mid px-5 py-2 text-base text-white shadow-sm transition hover:bg-zona-purple-deep"
+                style={{ fontFamily: "var(--font-sora)", fontWeight: 600 }}
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/portal/CounterOfferModal.tsx
+++ b/components/portal/CounterOfferModal.tsx
@@ -1,0 +1,341 @@
+"use client";
+
+// CounterOfferModal (Phase 4.5.i) — 2-phase form → result modal that wires
+// the seller-portal Counter action into POST /offers/{token}/counter.
+//
+// Counter amount is stored as a raw digit string in state; display value
+// adds locale thousand separators as the user types. Backend Pydantic
+// schema validates gt=0 / le=10_000_000 and notes max_length=500; client
+// performs a soft check so users see "minimum $1" / "maximum $10M" /
+// "notes too long" before a round trip. Server 400 → inline error.
+//
+// On success → router.refresh() so the Server Component re-fetches the
+// (now countered) terminal state.
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { counterOffer, PublicApiError } from "@/lib/publicApi";
+import { formatCurrency } from "@/lib/portalFormatters";
+import { IdentityVerificationFields } from "./IdentityVerificationFields";
+
+interface Props {
+  open: boolean;
+  token: string;
+  onClose: () => void;
+}
+
+type Phase = "form" | "result";
+
+const COUNTER_MAX = 10_000_000;
+const NOTES_MAX = 500;
+const NOTES_WARN = 450;
+
+interface SuccessState {
+  counterAmount: string;
+  message: string;
+}
+
+export function CounterOfferModal({ open, token, onClose }: Props) {
+  const router = useRouter();
+  const [phase, setPhase] = useState<Phase>("form");
+  const [name, setName] = useState("");
+  const [phoneLast4, setPhoneLast4] = useState("");
+  const [amountDigits, setAmountDigits] = useState("");
+  const [notes, setNotes] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<SuccessState | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setPhase("form");
+    setName("");
+    setPhoneLast4("");
+    setAmountDigits("");
+    setNotes("");
+    setSubmitting(false);
+    setSubmitError(null);
+    setSuccess(null);
+  }, [open]);
+
+  const handleClose = useCallback(() => {
+    if (submitting) return;
+    const wasSuccess = phase === "result";
+    onClose();
+    if (wasSuccess) {
+      router.refresh();
+    }
+  }, [submitting, phase, onClose, router]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") handleClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, handleClose]);
+
+  const amountNumeric = useMemo(() => {
+    if (!amountDigits) return 0;
+    const n = Number(amountDigits);
+    return Number.isFinite(n) ? n : 0;
+  }, [amountDigits]);
+
+  const displayAmount = useMemo(() => {
+    if (!amountDigits) return "";
+    return new Intl.NumberFormat("en-US").format(amountNumeric);
+  }, [amountDigits, amountNumeric]);
+
+  if (!open) return null;
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (submitting) return;
+    setSubmitError(null);
+
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      setSubmitError("Please enter your full name.");
+      return;
+    }
+    if (phoneLast4.length < 4) {
+      setSubmitError("Please enter the last 4 digits of your phone.");
+      return;
+    }
+    if (amountNumeric <= 0) {
+      setSubmitError("Counter amount must be at least $1.");
+      return;
+    }
+    if (amountNumeric > COUNTER_MAX) {
+      setSubmitError("Counter amount cannot exceed $10,000,000.");
+      return;
+    }
+    if (notes.length > NOTES_MAX) {
+      setSubmitError(`Notes cannot exceed ${NOTES_MAX} characters.`);
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const result = await counterOffer(token, {
+        identity_check_name: trimmedName,
+        identity_check_phone_last4: phoneLast4,
+        counter_amount: String(amountNumeric),
+        counter_notes: notes.trim() ? notes.trim() : null
+      });
+      setSuccess({
+        counterAmount: result.counter_amount,
+        message: result.message
+      });
+      setPhase("result");
+    } catch (err) {
+      const message =
+        err instanceof PublicApiError
+          ? err.message
+          : "Connection issue — please retry.";
+      setSubmitError(message);
+      setPhoneLast4("");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const notesOverLimit = notes.length > NOTES_MAX;
+  const notesWarn = notes.length >= NOTES_WARN && !notesOverLimit;
+
+  return (
+    <div
+      data-zona-gate="1"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-zona-navy/60 px-4 py-6"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="counter-modal-title"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) handleClose();
+      }}
+    >
+      <div className="max-h-[92vh] w-full max-w-md overflow-y-auto rounded-2xl bg-zona-off-white shadow-2xl">
+        {phase === "form" ? (
+          <form onSubmit={handleSubmit}>
+            <div className="space-y-5 px-6 py-6 md:px-8 md:py-7">
+              <div className="space-y-2">
+                <h2
+                  id="counter-modal-title"
+                  className="text-2xl text-zona-navy md:text-3xl"
+                  style={{ fontFamily: "var(--font-sora)", fontWeight: 600 }}
+                >
+                  Counter Offer
+                </h2>
+                <p
+                  className="text-base text-zona-navy/80"
+                  style={{ fontFamily: "var(--font-inter)" }}
+                >
+                  Tell us your number and we&apos;ll review. Most counters get a
+                  response within 1 business day.
+                </p>
+              </div>
+
+              <div className="space-y-1.5">
+                <label
+                  htmlFor="counter-amount"
+                  className="block text-sm text-zona-navy"
+                  style={{ fontFamily: "var(--font-inter)", fontWeight: 500 }}
+                >
+                  Your Counter Amount
+                </label>
+                <div className="relative">
+                  <span
+                    className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-base text-zona-navy/60"
+                    style={{ fontFamily: "var(--font-inter)" }}
+                    aria-hidden="true"
+                  >
+                    $
+                  </span>
+                  <input
+                    id="counter-amount"
+                    type="text"
+                    inputMode="numeric"
+                    value={displayAmount}
+                    onChange={(e) =>
+                      setAmountDigits(e.target.value.replace(/\D/g, "").slice(0, 9))
+                    }
+                    disabled={submitting}
+                    placeholder="0"
+                    className="w-full rounded-lg border border-zona-navy/15 bg-white px-3 py-2 pl-7 text-base text-zona-navy outline-none transition focus:border-zona-purple-mid focus:ring-2 focus:ring-zona-purple-mid/20 disabled:opacity-60"
+                    style={{ fontFamily: "var(--font-inter)" }}
+                  />
+                </div>
+                <p
+                  className="text-xs text-zona-navy/60"
+                  style={{ fontFamily: "var(--font-inter)" }}
+                >
+                  Minimum $1. Maximum $10,000,000.
+                </p>
+              </div>
+
+              <div className="space-y-1.5">
+                <label
+                  htmlFor="counter-notes"
+                  className="block text-sm text-zona-navy"
+                  style={{ fontFamily: "var(--font-inter)", fontWeight: 500 }}
+                >
+                  Notes (optional)
+                </label>
+                <textarea
+                  id="counter-notes"
+                  value={notes}
+                  onChange={(e) => setNotes(e.target.value)}
+                  disabled={submitting}
+                  rows={3}
+                  maxLength={NOTES_MAX}
+                  placeholder="What's the lowest you'd accept?"
+                  className="w-full rounded-lg border border-zona-navy/15 bg-white px-3 py-2 text-base text-zona-navy outline-none transition focus:border-zona-purple-mid focus:ring-2 focus:ring-zona-purple-mid/20 disabled:opacity-60"
+                  style={{ fontFamily: "var(--font-inter)" }}
+                />
+                <p
+                  className={`text-xs ${
+                    notesOverLimit
+                      ? "text-zona-orange"
+                      : notesWarn
+                      ? "text-zona-amber"
+                      : "text-zona-navy/60"
+                  }`}
+                  style={{ fontFamily: "var(--font-inter)" }}
+                >
+                  {notes.length} / {NOTES_MAX}
+                </p>
+              </div>
+
+              <IdentityVerificationFields
+                name={name}
+                phoneLast4={phoneLast4}
+                onChange={({ name: n, phoneLast4: p }) => {
+                  setName(n);
+                  setPhoneLast4(p);
+                }}
+                disabled={submitting}
+              />
+
+              {submitError ? (
+                <div
+                  role="alert"
+                  className="rounded-lg border border-zona-orange/40 bg-zona-orange/10 px-4 py-3"
+                >
+                  <p
+                    className="text-sm text-zona-navy"
+                    style={{ fontFamily: "var(--font-inter)" }}
+                  >
+                    {submitError}
+                  </p>
+                </div>
+              ) : null}
+            </div>
+
+            <div className="flex items-center justify-end gap-3 border-t border-zona-navy/10 bg-white px-6 py-4 md:px-8">
+              <button
+                type="button"
+                onClick={handleClose}
+                disabled={submitting}
+                className="rounded-lg px-4 py-2 text-base text-zona-navy/70 transition hover:text-zona-navy disabled:opacity-60"
+                style={{ fontFamily: "var(--font-inter)", fontWeight: 500 }}
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={submitting || notesOverLimit}
+                className="rounded-lg bg-zona-purple-mid px-5 py-2 text-base text-white shadow-sm transition hover:bg-zona-purple-deep disabled:opacity-60"
+                style={{ fontFamily: "var(--font-sora)", fontWeight: 600 }}
+              >
+                {submitting ? "Submitting…" : "Submit Counter"}
+              </button>
+            </div>
+          </form>
+        ) : (
+          <div>
+            <div className="space-y-3 px-6 py-6 md:px-8 md:py-7">
+              <h2
+                id="counter-modal-title"
+                className="text-2xl text-zona-navy md:text-3xl"
+                style={{ fontFamily: "var(--font-sora)", fontWeight: 600 }}
+              >
+                Counter Offer Sent
+              </h2>
+              <p
+                className="text-base text-zona-navy/85"
+                style={{ fontFamily: "var(--font-inter)" }}
+              >
+                {success?.message ??
+                  "Counter received. Our team will review and respond shortly."}
+              </p>
+              {success?.counterAmount ? (
+                <p
+                  className="text-sm text-zona-navy/70"
+                  style={{ fontFamily: "var(--font-inter)" }}
+                >
+                  Your counter of{" "}
+                  <span style={{ fontWeight: 600 }}>
+                    {formatCurrency(success.counterAmount)}
+                  </span>{" "}
+                  has been submitted. We&apos;ll review and respond within 1
+                  business day.
+                </p>
+              ) : null}
+            </div>
+            <div className="flex items-center justify-end gap-3 border-t border-zona-navy/10 bg-white px-6 py-4 md:px-8">
+              <button
+                type="button"
+                onClick={handleClose}
+                className="rounded-lg bg-zona-purple-mid px-5 py-2 text-base text-white shadow-sm transition hover:bg-zona-purple-deep"
+                style={{ fontFamily: "var(--font-sora)", fontWeight: 600 }}
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/portal/IdentityVerificationFields.tsx
+++ b/components/portal/IdentityVerificationFields.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+// Identity verification panel shared by AcceptOfferModal + CounterOfferModal
+// (Phase 4.5.i). NOT used by ContactModal — backend ContactRequest accepts
+// an empty body per blueprint §3.5.
+//
+// Backend identity service does case-insensitive token-set match requiring
+// BOTH first AND last name tokens; phone is digit-stripped and compared to
+// the trailing 4 of seller phone on file. Failure returns 400 with a generic
+// detail message that does NOT reveal which side mismatched (info-leak
+// defense per apps/api/app/api/routes/public_offers.py:170-178).
+
+interface Props {
+  name: string;
+  phoneLast4: string;
+  onChange: (fields: { name: string; phoneLast4: string }) => void;
+  nameError?: string;
+  phoneError?: string;
+  disabled?: boolean;
+}
+
+export function IdentityVerificationFields({
+  name,
+  phoneLast4,
+  onChange,
+  nameError,
+  phoneError,
+  disabled
+}: Props) {
+  return (
+    <div className="space-y-4">
+      <div
+        className="rounded-xl border border-zona-amber/40 bg-zona-amber/10 px-4 py-3"
+        role="note"
+      >
+        <p
+          className="text-sm text-zona-navy/80"
+          style={{ fontFamily: "var(--font-inter)" }}
+        >
+          Verifying your identity protects your offer from unauthorized access.
+        </p>
+      </div>
+
+      <div className="space-y-1.5">
+        <label
+          htmlFor="identity-name"
+          className="block text-sm text-zona-navy"
+          style={{ fontFamily: "var(--font-inter)", fontWeight: 500 }}
+        >
+          Your Full Legal Name
+        </label>
+        <input
+          id="identity-name"
+          type="text"
+          autoComplete="name"
+          value={name}
+          onChange={(e) => onChange({ name: e.target.value, phoneLast4 })}
+          disabled={disabled}
+          className="w-full rounded-lg border border-zona-navy/15 bg-white px-3 py-2 text-base text-zona-navy outline-none transition focus:border-zona-purple-mid focus:ring-2 focus:ring-zona-purple-mid/20 disabled:opacity-60"
+          style={{ fontFamily: "var(--font-inter)" }}
+          aria-invalid={nameError ? "true" : undefined}
+          aria-describedby={nameError ? "identity-name-error" : undefined}
+        />
+        {nameError ? (
+          <p
+            id="identity-name-error"
+            className="text-sm text-zona-orange"
+            style={{ fontFamily: "var(--font-inter)" }}
+          >
+            {nameError}
+          </p>
+        ) : null}
+      </div>
+
+      <div className="space-y-1.5">
+        <label
+          htmlFor="identity-phone-last4"
+          className="block text-sm text-zona-navy"
+          style={{ fontFamily: "var(--font-inter)", fontWeight: 500 }}
+        >
+          Last 4 Digits of Phone Number on File
+        </label>
+        <input
+          id="identity-phone-last4"
+          type="text"
+          inputMode="numeric"
+          maxLength={4}
+          autoComplete="off"
+          value={phoneLast4}
+          onChange={(e) =>
+            onChange({
+              name,
+              phoneLast4: e.target.value.replace(/\D/g, "").slice(0, 4)
+            })
+          }
+          disabled={disabled}
+          className="w-full rounded-lg border border-zona-navy/15 bg-white px-3 py-2 text-base text-zona-navy outline-none transition focus:border-zona-purple-mid focus:ring-2 focus:ring-zona-purple-mid/20 disabled:opacity-60"
+          style={{ fontFamily: "var(--font-inter)" }}
+          aria-invalid={phoneError ? "true" : undefined}
+          aria-describedby={phoneError ? "identity-phone-error" : undefined}
+        />
+        {phoneError ? (
+          <p
+            id="identity-phone-error"
+            className="text-sm text-zona-orange"
+            style={{ fontFamily: "var(--font-inter)" }}
+          >
+            {phoneError}
+          </p>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/components/portal/StickyActionBar.tsx
+++ b/components/portal/StickyActionBar.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+// StickyActionBar (Phase 4.5.i) — fixed bottom action surface that owns the
+// 3-modal state for Accept / Counter / Contact. Rendered only when parent
+// (app/offer/[token]/page.tsx) is in the active state — terminal states
+// never mount this component.
+//
+// Visual hierarchy per blueprint §3.4 + §3.5:
+//   - Accept   = PRIMARY (brand-purple-mid filled)
+//   - Counter  = SECONDARY (brand-amber outlined)
+//   - Contact  = TERTIARY (text-only navy link)
+//
+// Reading-width constrained (max-w-4xl) so the action bar mirrors the layer
+// container width above it. Container has z-30 so the page content can
+// scroll behind without bleeding through the top border + shadow.
+
+import { useState } from "react";
+import { AcceptOfferModal } from "./AcceptOfferModal";
+import { CounterOfferModal } from "./CounterOfferModal";
+import { ContactModal } from "./ContactModal";
+
+interface Props {
+  token: string;
+  targetOffer: string;
+}
+
+type ActiveModal = "accept" | "counter" | "contact" | null;
+
+export function StickyActionBar({ token, targetOffer }: Props) {
+  const [activeModal, setActiveModal] = useState<ActiveModal>(null);
+
+  return (
+    <>
+      <div className="fixed inset-x-0 bottom-0 z-30 border-t border-zona-navy/10 bg-zona-off-white/95 shadow-[0_-8px_24px_-12px_rgba(14,23,42,0.18)] backdrop-blur">
+        <div className="mx-auto max-w-4xl px-4 py-3 sm:px-6 sm:py-4">
+          <div className="flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <button
+              type="button"
+              onClick={() => setActiveModal("contact")}
+              className="order-3 text-base text-zona-navy/75 transition hover:text-zona-navy sm:order-1 sm:py-2"
+              style={{ fontFamily: "var(--font-inter)", fontWeight: 500 }}
+            >
+              Contact Zona
+            </button>
+
+            <div className="order-1 flex flex-col gap-3 sm:order-2 sm:flex-row sm:items-center sm:gap-3">
+              <button
+                type="button"
+                onClick={() => setActiveModal("counter")}
+                className="rounded-lg border-2 border-zona-amber bg-white px-5 py-2.5 text-base text-zona-navy shadow-sm transition hover:bg-zona-amber/10"
+                style={{ fontFamily: "var(--font-inter)", fontWeight: 500 }}
+              >
+                Counter
+              </button>
+              <button
+                type="button"
+                onClick={() => setActiveModal("accept")}
+                className="rounded-lg bg-zona-purple-mid px-6 py-2.5 text-base text-white shadow-sm transition hover:bg-zona-purple-deep"
+                style={{ fontFamily: "var(--font-sora)", fontWeight: 600 }}
+              >
+                Accept Offer
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <AcceptOfferModal
+        open={activeModal === "accept"}
+        token={token}
+        targetOffer={targetOffer}
+        onClose={() => setActiveModal(null)}
+      />
+      <CounterOfferModal
+        open={activeModal === "counter"}
+        token={token}
+        onClose={() => setActiveModal(null)}
+      />
+      <ContactModal
+        open={activeModal === "contact"}
+        token={token}
+        onClose={() => setActiveModal(null)}
+      />
+    </>
+  );
+}

--- a/lib/publicApi.ts
+++ b/lib/publicApi.ts
@@ -1,6 +1,11 @@
 import {
+  AcceptRequest,
+  AcceptResponse,
   AgentIntakePayload,
   BuyerIntakePayload,
+  ContactResponse,
+  CounterRequest,
+  CounterResponse,
   PublicOfferResponse,
   SellerLeadPayload,
   WholesalerIntakePayload
@@ -314,6 +319,79 @@ export async function fetchPublicOffer(token: string): Promise<PublicOfferRespon
   if (res.status === 404) return null;
   if (!res.ok) {
     throw new PublicApiError(`Failed to fetch offer: ${res.status}`, res.status);
+  }
+  return res.json();
+}
+
+// ---------------------------------------------------------------------------
+// Public Offer Portal actions (Phase 4.5.i)
+//
+// POST /offers/{token}/{accept,counter,contact}. Token URL-encoded per PR #12
+// Drift #3. Backend returns 400 with structured {detail: string} on every
+// failure mode (state conflict / identity mismatch / phone missing).
+// Pydantic 422 returns {detail: [{loc, msg, type}]} — extractDetail handles
+// both shapes. Network errors throw PublicApiError with a generic message
+// so callers can surface a retry-friendly UI hint.
+// ---------------------------------------------------------------------------
+
+async function extractDetail(res: Response, fallback: string): Promise<string> {
+  try {
+    const data = await res.json();
+    if (data && typeof data.detail === "string") return data.detail;
+    if (Array.isArray(data?.detail) && data.detail.length > 0) {
+      const first = data.detail[0];
+      if (first && typeof first.msg === "string") return first.msg;
+    }
+  } catch {
+    // fall through to fallback
+  }
+  return fallback;
+}
+
+export async function acceptOffer(
+  token: string,
+  payload: AcceptRequest
+): Promise<AcceptResponse> {
+  const res = await fetch(`${API_BASE_URL}/offers/${encodeURIComponent(token)}/accept`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    cache: "no-store",
+    body: JSON.stringify(payload)
+  });
+  if (!res.ok) {
+    const message = await extractDetail(res, `Failed to accept offer: ${res.status}`);
+    throw new PublicApiError(message, res.status);
+  }
+  return res.json();
+}
+
+export async function counterOffer(
+  token: string,
+  payload: CounterRequest
+): Promise<CounterResponse> {
+  const res = await fetch(`${API_BASE_URL}/offers/${encodeURIComponent(token)}/counter`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    cache: "no-store",
+    body: JSON.stringify(payload)
+  });
+  if (!res.ok) {
+    const message = await extractDetail(res, `Failed to submit counter: ${res.status}`);
+    throw new PublicApiError(message, res.status);
+  }
+  return res.json();
+}
+
+export async function contactZona(token: string): Promise<ContactResponse> {
+  const res = await fetch(`${API_BASE_URL}/offers/${encodeURIComponent(token)}/contact`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    cache: "no-store",
+    body: "{}"
+  });
+  if (!res.ok) {
+    const message = await extractDetail(res, `Failed to request contact: ${res.status}`);
+    throw new PublicApiError(message, res.status);
   }
   return res.json();
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -190,3 +190,51 @@ export interface PublicOfferResponse {
   countered_at: string | null;
   counter_amount: string | null;
 }
+
+// ---------------------------------------------------------------------------
+// Public Offer Portal action types (Phase 4.5.i)
+//
+// Mirror of backend Pydantic schemas in zona-admin at
+// apps/api/app/schemas/offer_actions.py per Scar #24. Backend serializes
+// Decimal as JSON strings via Pydantic V2 default — counter_amount typed
+// `string` on the wire (matches engine surface).
+// ---------------------------------------------------------------------------
+
+export interface AcceptRequest {
+  identity_check_name: string;
+  identity_check_phone_last4: string;
+}
+
+export interface AcceptResponse {
+  status: "accepted";
+  accepted_at: string;
+  message: string;
+}
+
+export interface CounterRequest {
+  identity_check_name: string;
+  identity_check_phone_last4: string;
+  counter_amount: string;
+  counter_notes?: string | null;
+}
+
+export interface CounterResponse {
+  status: "countered";
+  countered_at: string;
+  counter_amount: string;
+  message: string;
+}
+
+// Empty body; backend has model_config = ConfigDict(extra="forbid").
+export type ContactRequest = Record<string, never>;
+
+// Backend ships 4 fields (Scar #24/§18.2 catch — prompt mentioned only
+// zona_phone; full backend contract has all four per
+// apps/api/app/schemas/offer_actions.py:122-133). UI consumes
+// zona_phone today; remaining fields preserved for future use.
+export interface ContactResponse {
+  zona_phone: string;
+  zona_email: string;
+  property_address: string;
+  token_status: PublicOfferStatus;
+}


### PR DESCRIPTION
## Summary

**Phase 4.5.i — THE CLOSER.** Sticky action bar + Accept/Counter/Contact modals wire the seller-portal to the action endpoints shipped in 4.5.c. After this lands, sellers can act on offers end-to-end. First real customer-facing offer pending Twilio + SendGrid env vars at the backend (4.5.f).

8 files: 3 edits + 5 new components. Frontend-only. ZERO new deps. ZERO backend changes.

## Blueprint Conformance

**Implements:** `Zona_Desert_Offer_Delivery_Portal_v1.docx` §3.4 (Identity Confirmation) + §3.5 (Contact Button)

**Sections addressed in this PR:**
- §3.4: Accept + Counter require identity verification (full name + last-4 phone). Backend service does case-insensitive token-set match + digit-strip phone compare; failure surfaces inline without revealing which side mismatched (info-leak defense)
- §3.5: Contact button friction-light (no identity), available in any token state. Backend ContactRequest accepts empty body

**Sections explicitly NOT addressed (future PRs):**
- §6 (PDF Offer Package): defers to 4.5.j
- §7 (Admin Activity Feed): defers to 4.5.k
- §8 (Admin Lifecycle — revoke/extend): defers to 4.5.l
- CAPTCHA on actions: explicitly out of scope

**Conformance delta:** Phase 4.5 wave moves from 7/N → 8/N sub-phases shipped. Seller-portal CRUD loop (read + accept + counter + contact) is now complete pending PDF, admin activity feed, and admin lifecycle.

## Blueprint Conformance Verdict

**Blueprint implemented:** `Zona_Desert_Offer_Delivery_Portal_v1.docx` §3.4 + §3.5

**Sections truly addressed by this PR:**
1. §3.4: Identity verification panel (shared component) + 400-on-mismatch inline error handling with phone-clear / name-preserve UX
2. §3.5: Contact action with no identity check; result modal shows Zona phone with tel: link

**Sections claimed but NOT fully addressed (scope-creep risk):** None — scope cleanly limited to 8 files per prompt

**Honest status after this PR:** Seller-action surface CONFORMING to §3.4 + §3.5 for the active-state UX. Terminal-state shells render via TerminalState (PR #12). Lifecycle states (expired / accepted / countered / revoked) display correctly without action bar (active-only mount).

**What still remains for Phase 4.5 CONFORMING status:**
- §6: PDF Offer Package (4.5.j)
- §7: Admin Activity Feed wire-in (4.5.k)
- §8: Admin lifecycle endpoints — revoke + extend (4.5.l)

## Spec Compliance Self-Review

**Prompt deliverables — line-by-line:**
- ✅ `lib/types.ts` — APPENDED 6 action interfaces (AcceptRequest/Response, CounterRequest/Response, ContactRequest/Response)
- ⚠️ `ContactResponse` shape — shipped with drift: backend returns 4 fields (zona_phone + zona_email + property_address + token_status) per `apps/api/app/schemas/offer_actions.py:122-133`; prompt mentioned only `{zona_phone: str}`. Mirrored verbatim per Scar #24 + Rule 10.21. See Notable agent judgment #1
- ✅ `lib/publicApi.ts` — APPENDED `acceptOffer`, `counterOffer`, `contactZona` matching existing `fetchPublicOffer` pattern (no `/api/v1`, `cache: "no-store"`, `PublicApiError` on non-200, `encodeURIComponent` on token)
- ✅ `components/portal/IdentityVerificationFields.tsx` — `"use client"`, ~110 lines (slightly over the ~80 estimate due to ARIA wiring + 4-digit phone strip in onChange). Brand-amber-tinted privacy note + name input + numeric maxLength=4 phone input + inline error props
- ✅ `components/portal/AcceptOfferModal.tsx` — 2-phase confirm → result; identity verification; loading state; inline 400 error; phone-clear/name-preserve on identity failure; `router.refresh()` after success-close
- ✅ `components/portal/CounterOfferModal.tsx` — 2-phase form → result; dollar-prefixed numeric input with locale separators + raw digit state; optional notes textarea with 500-char cap + soft warn at 450; identity verification; `router.refresh()` after success-close
- ✅ `components/portal/ContactModal.tsx` — 2-phase confirm → result; NO identity verification (matches empty backend body); shows zona_phone with tel: link; NO `router.refresh()` (no state transition)
- ✅ `components/portal/StickyActionBar.tsx` — fixed bottom z-30 bar with brand-styled hierarchy (Contact tertiary text-link / Counter secondary amber-outlined / Accept primary purple-filled); owns `activeModal` state; reading-width constrained `max-w-4xl`
- ✅ `app/offer/[token]/page.tsx` — wired StickyActionBar into active state only; bumped layers container padding to `pb-32 sm:pb-24` for sticky bar overlap defense; terminal state dispatch UNCHANGED
- ✅ ESC + outside-click cleanup on all 3 modals (disabled while submitting)
- ✅ `data-zona-gate="1"` on all modal overlays (PR #12 cookie pattern)
- ✅ `npm run lint` + `npm run build` both green
- ✅ Sticky bar renders ONLY in active state; hidden in 4 terminal states (mounted by conditional in page.tsx)
- ✅ `router.refresh()` after Accept/Counter success; Contact does NOT refresh

**Scope additions (not in the prompt):**
- `extractDetail()` helper in `lib/publicApi.ts` — handles both FastAPI 400-shape (`{detail: string}`) and Pydantic 422-shape (`{detail: [{msg, ...}]}`). Required for honest error display; documented inline

**Scope cuts (in the prompt, not delivered):** None

**Net result:** All 8 file deliverables shipped with 1 drift item surfaced (ContactResponse shape mirrored verbatim from backend per Scar #24)

**STATUS:** DONE_WITH_CONCERNS

## Notable agent judgment

**1. ContactResponse shape mirrored verbatim (Rule 10.21 + Scar #24)** — Prompt specified `ContactResponse { zona_phone: string }`. Verbatim recon of `apps/api/app/schemas/offer_actions.py:122-133` confirmed backend ships 4 fields: `zona_phone`, `zona_email`, `property_address`, `token_status`. Implementing the prompt literally would have caused TypeScript-runtime drift (the deserialized response carries 4 fields; only 1 was typed). Mirrored the full backend contract; UI consumes `zona_phone` today, remaining fields preserved for future use. Documented inline in `lib/types.ts` and surfaced here per Rule 10.21 discipline.

**2. `extractDetail` helper added to handle 422 array shape** — FastAPI 400 errors are `{detail: string}`; Pydantic schema-validation 422 errors are `{detail: [{loc, msg, type}]}`. Counter amount or notes validation that misses the wire (e.g., extra fields stripped by `extra="forbid"`) will return 422. Helper extracts the first `msg` from the array shape; falls back to a status-code message if the shape doesn't match either contract. Required for honest error UX; out of strict scope but in spirit of "display backend detail" requirement.

**3. Counter amount stored as raw digit string** — Avoids float precision drift entirely. State is `amountDigits: string` (digits-only, capped at 9 chars = $999,999,999), display computes via `Intl.NumberFormat`, submission converts to `String(Number(amountDigits))`. Backend Pydantic V2 accepts both JSON numbers and JSON strings for `Decimal`. Locale separators applied only to the display value, never the stored or submitted value.

**4. Counter notes 500-char cap soft warn at 450** — Chose 450 as the warn threshold per "soft warn" UX guidance in the prompt. `maxLength={500}` on textarea is a hard browser cap; if user pastes >500 chars, the textarea truncates. Soft warn (amber) at 450, hard error (orange) at >500 — the latter only triggers if state is mutated programmatically since the textarea won't allow it.

**5. Phone last4 onChange strips non-digits live** — UX detail: typing "(555) 1234" or "ext-1234" into the phone input strips to "1234" as the user types. Matches backend service which digit-strips. Prevents valid input from looking invalid client-side.

## Verified facts (Scar #24 pre-write recon)

- ✅ 4.5.c request/response schemas mirrored verbatim from `apps/api/app/schemas/offer_actions.py`
- ✅ 400 error detail field name (`detail`) honored from `apps/api/app/api/routes/public_offers.py:160-178`
- ✅ Pydantic 422 detail-as-array shape handled by `extractDetail`
- ✅ All 3 action endpoint shapes correct (POST + JSON body + `cache: "no-store"`)
- ✅ Identity verification UX matches backend `identity_check_name` + `identity_check_phone_last4` field names
- ✅ `router.refresh()` pattern correct for Accept/Counter (state changes); Contact does NOT refresh (no state change)
- ✅ Sticky bar only mounted in active state via page.tsx conditional
- ✅ `pb-32 sm:pb-24` bottom padding compensates for sticky bar height
- ✅ Modal ESC + outside-click cleanup; submitting state disables both
- ✅ `npm run lint` + `npm run build` green

## Test plan

- [ ] Visit `/offer/{active-token}` — verify sticky bar renders at bottom with 3 buttons in correct hierarchy
- [ ] Click "Accept Offer" → modal opens with confirm phase + identity fields
- [ ] Submit without name → inline error "Please enter your full name"
- [ ] Submit with valid identity → 200 → result phase → close → page re-fetches → TerminalState renders accepted
- [ ] Submit with wrong identity → 400 → inline error from backend detail; phone clears, name preserved
- [ ] Click "Counter" → modal opens with form phase
- [ ] Type "85000" in amount → displays as "85,000"; submit with valid identity → 200 → result phase
- [ ] Try amount > $10M → client-side error "cannot exceed $10,000,000"
- [ ] Click "Contact Zona" → modal opens; click "Request Contact" → 200 → zona_phone shown with tel: link
- [ ] Close Contact modal → action bar still visible (no router.refresh)
- [ ] ESC on each modal → closes; outside-click → closes
- [ ] Visit `/offer/{expired-token}` — terminal state renders WITHOUT sticky bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)