### PR TITLE
[Phase 5.5.b] feat: 3-tab public listing interface + gallery

### DIFF
--- a/app/(site)/listings/[state]/[city]/[slug]/page.tsx
+++ b/app/(site)/listings/[state]/[city]/[slug]/page.tsx
@@ -1,28 +1,34 @@
-import Image from "next/image";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 
+import BidBuyPanel from "@/components/listings/BidBuyPanel";
+import DealDataPanel from "@/components/listings/DealDataPanel";
+import ListingTabs from "@/components/listings/ListingTabs";
+import OverviewPanel from "@/components/listings/OverviewPanel";
 import { fetchPublicListing } from "@/lib/publicApi";
 import type { PublicListingDetail } from "@/lib/types";
 
-// Phase 5.5.a — Public Listing Foundation.
+// Phase 5.5.b — Public Listing 3-Tab Interface.
 //
 // Blueprint-locked nested URL: zonadesert.com/listings/[state]/[city]/[slug].
 // state + city URL segments are SEO/readability only; the slug is the
-// globally-unique lookup key (enforced at the backend ORM layer via
-// Listing.public_slug UNIQUE). A future polish PR may add canonical
-// redirect when state/city in the URL don't match the listing's actual
-// state/city — out of scope here.
+// globally-unique lookup key.
 //
-// SSR Server Component (no "use client") — marketing pages MUST be
-// crawlable for SEO. generateMetadata derives title + description from
-// the real backend data so the served HTML carries unique meta per
-// listing.
+// SSR Server Component (no "use client"). All three tab panels render
+// server-side so search engines see the full listing payload in the
+// initial HTML. The `ListingTabs` client island toggles visibility only;
+// disabling JavaScript still leaves the Overview panel visible.
 //
-// Base shell ONLY — 3-tab Overview/Bid&Buy/Deal Data interface, full
-// photo carousel, OG/Twitter cards, Zona Agent chatbox, live bidding,
-// Buy Now + Stripe deposit all land in subsequent 5.5.b+ slices.
+// generateMetadata now ships full OG + Twitter Card meta for richer
+// previews when listings are shared. og:image falls back to the local
+// hero asset when a listing has no photos so social cards never break.
+//
+// Out of scope for this slice (later 5.5.c / 5.6 / 5.7 / 5.9):
+//   * Zona Agent chatbox
+//   * Live bid submission + websocket pricing
+//   * Buy Now + Stripe deposit flow
+//   * Buyer authentication / registration
 
 interface RouteParams {
   state: string;
@@ -35,11 +41,10 @@ interface PageProps {
 }
 
 const FALLBACK_HERO = "/hero-bg.png";
-
-function formatCurrency(value: number | null | undefined): string | null {
-  if (value == null || !Number.isFinite(value)) return null;
-  return `$${Math.round(value).toLocaleString()}`;
-}
+const SITE_ORIGIN = (process.env.NEXT_PUBLIC_SITE_URL ?? "https://zonadesert.com").replace(
+  /\/+$/,
+  ""
+);
 
 function formatStatusLabel(status: string | null | undefined): string {
   if (!status) return "Live";
@@ -63,6 +68,14 @@ function buildLocaleLine(listing: PublicListingDetail): string {
   return parts.join(", ");
 }
 
+function resolveOgImage(listing: PublicListingDetail): string {
+  const firstPhoto = listing.photos?.find((src) => src && src.trim().length > 0);
+  const thumbnail = listing.thumbnail_url?.trim();
+  if (firstPhoto) return firstPhoto;
+  if (thumbnail) return thumbnail;
+  return `${SITE_ORIGIN}${FALLBACK_HERO}`;
+}
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const listing = await fetchPublicListing(params.slug);
   if (!listing) {
@@ -76,9 +89,34 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const description = descriptionRaw
     ? `${locale ? `${locale} • ` : ""}${descriptionRaw.slice(0, 140)}${descriptionRaw.length > 140 ? "…" : ""}`
     : `Investor-ready opportunity${locale ? ` in ${locale}` : ""} on Zona Desert.`;
+  const title = `${listing.title} | Zona Desert`;
+  const ogImage = resolveOgImage(listing);
+  const url = `${SITE_ORIGIN}/listings/${encodeURIComponent(params.state)}/${encodeURIComponent(
+    params.city
+  )}/${encodeURIComponent(params.slug)}`;
+
   return {
-    title: `${listing.title} | Zona Desert`,
-    description
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      url,
+      siteName: "Zona Desert",
+      type: "website",
+      images: [
+        {
+          url: ogImage,
+          alt: buildAddressLine(listing)
+        }
+      ]
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [ogImage]
+    }
   };
 }
 
@@ -88,24 +126,12 @@ export default async function PublicListingDetailPage({ params }: PageProps) {
     notFound();
   }
 
-  const heroSrc = listing.photos?.[0]?.trim() || listing.thumbnail_url?.trim() || FALLBACK_HERO;
   const addressLine = buildAddressLine(listing);
   const localeLine = buildLocaleLine(listing);
   const statusLabel = formatStatusLabel(listing.status);
 
-  const startingBid = formatCurrency(listing.starting_bid);
-  const buyNow = formatCurrency(listing.buy_now_price);
-  const askingPrice = formatCurrency(listing.price);
-
-  const keyFacts: Array<{ label: string; value: string }> = [];
-  if (listing.beds != null) keyFacts.push({ label: "Beds", value: String(listing.beds) });
-  if (listing.baths != null) keyFacts.push({ label: "Baths", value: String(listing.baths) });
-  if (listing.sqft != null) keyFacts.push({ label: "Sq Ft", value: listing.sqft.toLocaleString() });
-  if (listing.lot_size != null) keyFacts.push({ label: "Lot Size", value: `${listing.lot_size.toLocaleString()} sqft` });
-  if (listing.rehab_level) keyFacts.push({ label: "Rehab Level", value: formatStatusLabel(listing.rehab_level) });
-
   return (
-    <div className="mx-auto max-w-4xl space-y-10 px-4 py-16">
+    <div className="mx-auto max-w-5xl space-y-8 px-4 py-12 sm:py-16">
       <div className="space-y-3">
         <Link
           href="/listings"
@@ -121,66 +147,21 @@ export default async function PublicListingDetailPage({ params }: PageProps) {
             <span className="text-sm font-semibold text-slate-500">{localeLine}</span>
           ) : null}
         </div>
-        <h1 className="text-4xl font-semibold text-slate-900">{addressLine}</h1>
-        {localeLine ? (
-          <p className="text-lg text-slate-600">{localeLine}</p>
-        ) : null}
+        <h1 className="text-3xl font-semibold text-slate-900 sm:text-4xl">{addressLine}</h1>
+        {localeLine ? <p className="text-lg text-slate-600">{localeLine}</p> : null}
       </div>
 
-      <div className="overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm">
-        <div className="relative h-72 w-full sm:h-96">
-          <Image
-            src={heroSrc}
-            alt={addressLine}
-            fill
-            priority
-            sizes="(min-width: 1024px) 64rem, 100vw"
-            className="object-cover"
+      <ListingTabs
+        overview={
+          <OverviewPanel
+            listing={listing}
+            addressLine={addressLine}
+            localeLine={localeLine}
           />
-        </div>
-      </div>
-
-      <div className="rounded-3xl border border-slate-200 bg-white p-8 shadow-sm">
-        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Pricing</p>
-        <div className="mt-4 grid gap-6 sm:grid-cols-3">
-          <div>
-            <p className="text-xs font-semibold text-slate-500">Starting Bid</p>
-            <p className="mt-1 text-3xl font-bold text-slate-900">{startingBid ?? "—"}</p>
-          </div>
-          <div>
-            <p className="text-xs font-semibold text-slate-500">Buy Now</p>
-            <p className="mt-1 text-3xl font-bold text-zona-purple">{buyNow ?? "—"}</p>
-          </div>
-          <div>
-            <p className="text-xs font-semibold text-slate-500">Asking</p>
-            <p className="mt-1 text-3xl font-bold text-slate-900">{askingPrice ?? "—"}</p>
-          </div>
-        </div>
-        {!startingBid && !buyNow && !askingPrice ? (
-          <p className="mt-4 text-sm text-slate-500">Price on request.</p>
-        ) : null}
-      </div>
-
-      {keyFacts.length > 0 ? (
-        <div className="rounded-3xl border border-slate-200 bg-white p-8 shadow-sm">
-          <h2 className="text-xl font-semibold text-slate-900">Key Facts</h2>
-          <dl className="mt-6 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-            {keyFacts.map((fact) => (
-              <div key={fact.label} className="border-l-2 border-slate-100 pl-4">
-                <dt className="text-xs font-semibold text-slate-500">{fact.label}</dt>
-                <dd className="mt-1 text-lg font-semibold text-slate-900">{fact.value}</dd>
-              </div>
-            ))}
-          </dl>
-        </div>
-      ) : null}
-
-      {listing.description ? (
-        <div className="rounded-3xl border border-slate-200 bg-white p-8 shadow-sm">
-          <h2 className="text-xl font-semibold text-slate-900">About this property</h2>
-          <p className="mt-4 whitespace-pre-line text-slate-600">{listing.description}</p>
-        </div>
-      ) : null}
+        }
+        bidBuy={<BidBuyPanel listing={listing} />}
+        dealData={<DealDataPanel listing={listing} />}
+      />
     </div>
   );
 }

--- a/components/listings/BidBuyPanel.tsx
+++ b/components/listings/BidBuyPanel.tsx
@@ -1,0 +1,227 @@
+import Link from "next/link";
+
+import type { PublicListingDetail } from "@/lib/types";
+
+// Phase 5.5.b — Bid & Buy tab content.
+//
+// Server component. Shows pricing + timeline + bidding rules.
+//
+// CTAs are STUBBED in this slice — they route toward the buyer auth
+// flow (5.9) with the listing slug + intended action preserved in the
+// query string. The real bid submission flow lands in 5.6 and the
+// Buy Now + Stripe deposit flow in 5.7.
+//
+// Hardcoded business-rule constants are surfaced as user-facing copy
+// rather than mutable config so the seller portal always reflects the
+// canonical contract. The values are mirrored from AGENTS.md §12:
+// min bid increment $500, 10-min late-bid extension, $250 deposit,
+// 3-hour deposit window, bidding closes 48h before inspection.
+
+const MIN_BID_INCREMENT_USD = 500;
+const DEPOSIT_USD = 250;
+const DEPOSIT_WINDOW_HOURS = 3;
+const LATE_BID_EXTENSION_MIN = 10;
+const BIDDING_CLOSES_BEFORE_INSPECTION_HOURS = 48;
+
+function formatCurrency(value: number | null | undefined): string | null {
+  if (value == null || !Number.isFinite(value)) return null;
+  return `$${Math.round(value).toLocaleString()}`;
+}
+
+function formatDeadline(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed.toLocaleString("en-US", {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZoneName: "short"
+  });
+}
+
+// SOLD / UNDER_CONTRACT / RELISTED / EXPIRED — the listing is no longer
+// open for new bids. We keep the panel visible for transparency but
+// disable the CTAs with a contextual note.
+function isTerminalState(status: string | null | undefined): {
+  closed: boolean;
+  note: string | null;
+} {
+  if (!status) return { closed: false, note: null };
+  const normalized = status.toLowerCase();
+  if (normalized === "sold") return { closed: true, note: "This property has sold." };
+  if (normalized === "under_contract")
+    return { closed: true, note: "This property is currently under contract." };
+  if (normalized === "awaiting_deposit")
+    return {
+      closed: true,
+      note: "The winning bidder is in the deposit window. Bidding is paused."
+    };
+  if (normalized === "expired")
+    return { closed: true, note: "Bidding for this listing has ended." };
+  return { closed: false, note: null };
+}
+
+interface BidBuyPanelProps {
+  listing: PublicListingDetail;
+}
+
+export default function BidBuyPanel({ listing }: BidBuyPanelProps) {
+  const startingBid = formatCurrency(listing.starting_bid);
+  const buyNowPrice = formatCurrency(listing.buy_now_price);
+  const askingPrice = formatCurrency(listing.price);
+  const biddingClosesFormatted = formatDeadline(listing.bidding_closes_at);
+  const { closed, note: terminalNote } = isTerminalState(listing.status);
+
+  const listingSlug = listing.slug ?? String(listing.id);
+  const bidHref = `/sign-in?return=/listings&listing=${encodeURIComponent(listingSlug)}&action=bid`;
+  const buyNowHref = `/sign-in?return=/listings&listing=${encodeURIComponent(
+    listingSlug
+  )}&action=buy-now`;
+
+  return (
+    <div className="space-y-8">
+      <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
+        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Pricing</p>
+        <div className="mt-4 grid gap-6 sm:grid-cols-3">
+          <div>
+            <p className="text-xs font-semibold text-slate-500">Starting Bid</p>
+            <p className="mt-1 text-3xl font-bold text-slate-900">{startingBid ?? "—"}</p>
+            <p className="mt-1 text-xs text-slate-500">
+              Minimum increment ${MIN_BID_INCREMENT_USD.toLocaleString()}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs font-semibold text-slate-500">Buy Now</p>
+            <p className="mt-1 text-3xl font-bold text-zona-purple">{buyNowPrice ?? "—"}</p>
+            <p className="mt-1 text-xs text-slate-500">Skip the auction. Lock the deal today.</p>
+          </div>
+          <div>
+            <p className="text-xs font-semibold text-slate-500">Asking</p>
+            <p className="mt-1 text-3xl font-bold text-slate-900">{askingPrice ?? "—"}</p>
+            <p className="mt-1 text-xs text-slate-500">Reference target price.</p>
+          </div>
+        </div>
+        {!startingBid && !buyNowPrice && !askingPrice ? (
+          <p className="mt-4 text-sm text-slate-500">Price on request.</p>
+        ) : null}
+      </div>
+
+      <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
+        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+          Bidding Timeline
+        </p>
+        {biddingClosesFormatted ? (
+          <p className="mt-4 text-2xl font-semibold text-slate-900">
+            Bidding closes {biddingClosesFormatted}
+          </p>
+        ) : (
+          <p className="mt-4 text-lg text-slate-600">
+            Bidding timeline TBD — check back soon or reach out for the latest.
+          </p>
+        )}
+        <ul className="mt-6 space-y-3 text-sm text-slate-600">
+          <li className="flex gap-3">
+            <span aria-hidden className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-zona-purple" />
+            <span>
+              Any bid placed within the final {LATE_BID_EXTENSION_MIN} minutes extends bidding by
+              another {LATE_BID_EXTENSION_MIN} minutes to keep the auction fair.
+            </span>
+          </li>
+          <li className="flex gap-3">
+            <span aria-hidden className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-zona-purple" />
+            <span>
+              Bidding closes {BIDDING_CLOSES_BEFORE_INSPECTION_HOURS} hours before inspection so
+              buyers have time to confirm their decision.
+            </span>
+          </li>
+        </ul>
+      </div>
+
+      <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
+        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+          Deposit & Commitment
+        </p>
+        <div className="mt-4 grid gap-4 sm:grid-cols-2">
+          <div>
+            <p className="text-xs font-semibold text-slate-500">Bidder Deposit</p>
+            <p className="mt-1 text-2xl font-bold text-slate-900">
+              ${DEPOSIT_USD.toLocaleString()}
+            </p>
+            <p className="mt-1 text-xs text-slate-500">
+              Held to confirm the winning bid. Refunded if you don&apos;t win.
+            </p>
+          </div>
+          <div>
+            <p className="text-xs font-semibold text-slate-500">Deposit Window</p>
+            <p className="mt-1 text-2xl font-bold text-slate-900">
+              {DEPOSIT_WINDOW_HOURS} hours
+            </p>
+            <p className="mt-1 text-xs text-slate-500">
+              Winning bidder commits the deposit within {DEPOSIT_WINDOW_HOURS} hours of close.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-lg shadow-slate-300/30 sm:p-8">
+        <p className="text-xs font-semibold uppercase tracking-wide text-zona-purple">
+          Next Steps
+        </p>
+        <p className="mt-3 text-2xl font-semibold text-slate-900">
+          {closed ? "Bidding is closed" : "Sign in to bid or buy now"}
+        </p>
+        {terminalNote ? (
+          <p className="mt-2 text-sm font-semibold text-zona-orange">{terminalNote}</p>
+        ) : (
+          <p className="mt-2 text-sm text-slate-500">
+            We&apos;ll verify your account with a quick sign-in. You&apos;ll return right back to
+            this listing with your action ready to confirm.
+          </p>
+        )}
+        <div className="mt-6 grid gap-3 sm:grid-cols-2">
+          {closed ? (
+            <>
+              <button
+                type="button"
+                disabled
+                className="w-full cursor-not-allowed rounded-2xl bg-slate-200 px-6 py-4 text-base font-semibold text-slate-500"
+              >
+                Place Bid
+              </button>
+              <button
+                type="button"
+                disabled
+                className="w-full cursor-not-allowed rounded-2xl bg-slate-200 px-6 py-4 text-base font-semibold text-slate-500"
+              >
+                Buy Now
+              </button>
+            </>
+          ) : (
+            <>
+              <Link
+                href={bidHref}
+                className="w-full rounded-2xl border-2 border-zona-purple bg-white px-6 py-4 text-center text-base font-semibold text-zona-purple shadow-sm transition hover:-translate-y-0.5 hover:bg-zona-purple/5"
+              >
+                Sign in to Place Bid
+              </Link>
+              <Link
+                href={buyNowHref}
+                className="w-full rounded-2xl bg-zona-purple px-6 py-4 text-center text-base font-semibold text-white shadow-lg shadow-zona-purple/30 transition hover:-translate-y-0.5 hover:bg-zona-purple/90"
+              >
+                Sign in to Buy Now
+              </Link>
+            </>
+          )}
+        </div>
+        <p className="mt-4 text-xs text-slate-500">
+          Buyer accounts unlock bidding, deposit, and Buy Now — coming soon. Until then, you can
+          still get the deal pack and talk to us about this property.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/components/listings/DealDataPanel.tsx
+++ b/components/listings/DealDataPanel.tsx
@@ -1,0 +1,209 @@
+import type { PublicListingDetail } from "@/lib/types";
+
+// Phase 5.5.b — Deal Data tab content.
+//
+// Server component. Investor analysis surface: financials breakdown,
+// cap rate, exit strategies, rehab level, structure / seller-finance.
+//
+// reserve_price is NEVER in the DTO — the backend schema strips it
+// per AGENTS.md §10.9 + the public_listings privacy-regression test.
+// This panel has no way to render what isn't in the response payload.
+
+function formatCurrency(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value)) return "—";
+  return `$${Math.round(value).toLocaleString()}`;
+}
+
+function formatPercent(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value)) return "—";
+  return `${value.toFixed(2)}%`;
+}
+
+function formatMonths(months: number | null | undefined): string {
+  if (months == null || !Number.isFinite(months)) return "—";
+  if (months >= 12 && months % 12 === 0) {
+    const years = months / 12;
+    return `${years} ${years === 1 ? "year" : "years"}`;
+  }
+  return `${months} months`;
+}
+
+// Aligns with the Phase 4.4 StrategyName vocabulary + 5.1.api rehab
+// taxonomy. The display labels are friendly versions of the canonical
+// snake_case enum values that flow through the public DTO.
+const EXIT_STRATEGY_LABELS: Record<string, string> = {
+  fix_and_flip: "Fix and Flip",
+  rental_hold: "Rental Hold",
+  brrrr: "BRRRR",
+  wholetail: "Wholetail"
+};
+
+const REHAB_LEVEL_LABELS: Record<string, string> = {
+  turnkey: "Turnkey",
+  light: "Light",
+  moderate: "Moderate",
+  heavy_plus: "Heavy +"
+};
+
+function formatExitStrategy(strategy: string): string {
+  return (
+    EXIT_STRATEGY_LABELS[strategy.toLowerCase()] ??
+    strategy
+      .split("_")
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(" ")
+  );
+}
+
+function formatRehabLevel(level: string | null | undefined): string {
+  if (!level) return "—";
+  return (
+    REHAB_LEVEL_LABELS[level.toLowerCase()] ??
+    level
+      .split("_")
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(" ")
+  );
+}
+
+interface DealDataPanelProps {
+  listing: PublicListingDetail;
+}
+
+export default function DealDataPanel({ listing }: DealDataPanelProps) {
+  const financials = listing.financials ?? {
+    estimated_rent: null,
+    taxes: null,
+    insurance: null,
+    hoa: null,
+    other_expenses: null
+  };
+  const structure = listing.structure ?? { cash_price: null, seller_finance: null };
+  const exitStrategies = (listing.exit_strategies ?? []).filter(
+    (s) => s && s.trim().length > 0
+  );
+
+  const financialRows = [
+    { label: "Estimated Monthly Rent", value: financials.estimated_rent },
+    { label: "Property Taxes (annual)", value: financials.taxes },
+    { label: "Insurance (annual)", value: financials.insurance },
+    { label: "HOA (annual)", value: financials.hoa },
+    { label: "Other Expenses (annual)", value: financials.other_expenses }
+  ];
+  const financialsAllNull = financialRows.every(({ value }) => value == null);
+
+  return (
+    <div className="space-y-8">
+      <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
+        <h2 className="text-xl font-semibold text-slate-900">Financials</h2>
+        {financialsAllNull ? (
+          <p className="mt-4 text-sm text-slate-500">
+            Detailed financials for this property aren&apos;t available yet. Reach out to request
+            the full deal pack.
+          </p>
+        ) : (
+          <dl className="mt-6 divide-y divide-slate-100">
+            {financialRows.map((row) => (
+              <div
+                key={row.label}
+                className="flex items-center justify-between py-3 text-sm sm:text-base"
+              >
+                <dt className="font-medium text-slate-600">{row.label}</dt>
+                <dd className="font-semibold text-slate-900">{formatCurrency(row.value)}</dd>
+              </div>
+            ))}
+            <div className="flex items-center justify-between py-3 text-sm sm:text-base">
+              <dt className="font-medium text-slate-600">Cap Rate</dt>
+              <dd className="font-semibold text-slate-900">{formatPercent(listing.cap_rate)}</dd>
+            </div>
+          </dl>
+        )}
+      </div>
+
+      <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
+        <h2 className="text-xl font-semibold text-slate-900">Strategy Fit</h2>
+        <div className="mt-6 grid gap-6 sm:grid-cols-2">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+              Best-Fit Exit Strategies
+            </p>
+            {exitStrategies.length > 0 ? (
+              <div className="mt-3 flex flex-wrap gap-2">
+                {exitStrategies.map((strategy) => (
+                  <span
+                    key={strategy}
+                    className="rounded-full bg-zona-purple/10 px-3 py-1 text-xs font-semibold text-zona-purple"
+                  >
+                    {formatExitStrategy(strategy)}
+                  </span>
+                ))}
+              </div>
+            ) : (
+              <p className="mt-3 text-sm text-slate-500">No strategies listed yet.</p>
+            )}
+          </div>
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+              Rehab Level
+            </p>
+            <p className="mt-3 text-lg font-semibold text-slate-900">
+              {formatRehabLevel(listing.rehab_level)}
+            </p>
+            {listing.rehab_level ? (
+              <p className="mt-1 text-xs text-slate-500">
+                Aligns with buyer rehab-tolerance bucket for matching.
+              </p>
+            ) : null}
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
+        <h2 className="text-xl font-semibold text-slate-900">Deal Structure</h2>
+        <div className="mt-6 space-y-6">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+              Cash Price
+            </p>
+            <p className="mt-2 text-2xl font-bold text-slate-900">
+              {formatCurrency(structure.cash_price ?? listing.price ?? null)}
+            </p>
+          </div>
+
+          {structure.seller_finance ? (
+            <div className="rounded-2xl border border-slate-200 bg-slate-50/60 p-5">
+              <p className="text-xs font-semibold uppercase tracking-wide text-zona-purple">
+                Seller Finance Available
+              </p>
+              <dl className="mt-4 grid gap-4 sm:grid-cols-3">
+                <div>
+                  <dt className="text-xs font-semibold text-slate-500">Down Payment</dt>
+                  <dd className="mt-1 text-lg font-semibold text-slate-900">
+                    {formatCurrency(structure.seller_finance.down_payment)}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-xs font-semibold text-slate-500">Interest Rate</dt>
+                  <dd className="mt-1 text-lg font-semibold text-slate-900">
+                    {formatPercent(structure.seller_finance.interest_rate)}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-xs font-semibold text-slate-500">Term</dt>
+                  <dd className="mt-1 text-lg font-semibold text-slate-900">
+                    {formatMonths(structure.seller_finance.term_months)}
+                  </dd>
+                </div>
+              </dl>
+              {structure.seller_finance.notes ? (
+                <p className="mt-4 whitespace-pre-line text-sm text-slate-600">
+                  {structure.seller_finance.notes}
+                </p>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/listings/ListingTabs.tsx
+++ b/components/listings/ListingTabs.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { ReactNode, useState } from "react";
+
+// Phase 5.5.b — public listing 3-tab shell.
+//
+// SSR DISCIPLINE: this is a TINY client island that toggles visibility
+// CSS classes on already-rendered server panels. Tab content is rendered
+// server-side by the parent page so search-engine crawlers see the full
+// listing payload in the initial HTML. JavaScript only swaps which panel
+// is visible; turning JS off leaves the user on Overview with no broken
+// UI.
+
+type TabId = "overview" | "bid-buy" | "deal-data";
+
+interface TabDefinition {
+  id: TabId;
+  label: string;
+}
+
+const TABS: readonly TabDefinition[] = [
+  { id: "overview", label: "Overview" },
+  { id: "bid-buy", label: "Bid & Buy" },
+  { id: "deal-data", label: "Deal Data" }
+];
+
+interface ListingTabsProps {
+  overview: ReactNode;
+  bidBuy: ReactNode;
+  dealData: ReactNode;
+}
+
+export default function ListingTabs({ overview, bidBuy, dealData }: ListingTabsProps) {
+  const [activeTab, setActiveTab] = useState<TabId>("overview");
+
+  const panels: Record<TabId, ReactNode> = {
+    overview,
+    "bid-buy": bidBuy,
+    "deal-data": dealData
+  };
+
+  return (
+    <div>
+      <div
+        role="tablist"
+        aria-label="Listing detail sections"
+        className="sticky top-0 z-10 -mx-4 flex gap-1 overflow-x-auto border-b border-slate-200 bg-white/95 px-4 backdrop-blur sm:mx-0 sm:gap-2 sm:px-0"
+      >
+        {TABS.map((tab) => {
+          const isActive = activeTab === tab.id;
+          return (
+            <button
+              key={tab.id}
+              type="button"
+              role="tab"
+              aria-selected={isActive}
+              aria-controls={`panel-${tab.id}`}
+              id={`tab-${tab.id}`}
+              onClick={() => setActiveTab(tab.id)}
+              className={`whitespace-nowrap border-b-2 px-4 py-3 text-sm font-semibold transition ${
+                isActive
+                  ? "border-zona-purple text-zona-purple"
+                  : "border-transparent text-slate-500 hover:border-slate-300 hover:text-slate-700"
+              }`}
+            >
+              {tab.label}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="mt-8">
+        {TABS.map((tab) => (
+          <section
+            key={tab.id}
+            role="tabpanel"
+            id={`panel-${tab.id}`}
+            aria-labelledby={`tab-${tab.id}`}
+            hidden={activeTab !== tab.id}
+            className={activeTab === tab.id ? "space-y-8" : ""}
+          >
+            {panels[tab.id]}
+          </section>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/listings/OverviewPanel.tsx
+++ b/components/listings/OverviewPanel.tsx
@@ -1,0 +1,126 @@
+import Image from "next/image";
+
+import ListingPhotoGallery from "@/components/ListingPhotoGallery";
+import type { PublicListingDetail } from "@/lib/types";
+
+// Phase 5.5.b — Overview tab content.
+//
+// Server component: rendered at the page level so the full content
+// ships in the initial SSR HTML (crawlable). The only client island
+// in this tree is the existing `ListingPhotoGallery` lightbox.
+
+const FALLBACK_HERO = "/hero-bg.png";
+
+function formatStatusLabel(status: string | null | undefined): string {
+  if (!status) return "Live";
+  return status
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+interface OverviewPanelProps {
+  listing: PublicListingDetail;
+  addressLine: string;
+  localeLine: string;
+}
+
+export default function OverviewPanel({ listing, addressLine, localeLine }: OverviewPanelProps) {
+  const photos = (listing.photos ?? []).filter((src) => src && src.trim().length > 0);
+  const heroSrc = photos[0] || listing.thumbnail_url?.trim() || FALLBACK_HERO;
+
+  const keyFacts: Array<{ label: string; value: string }> = [];
+  if (listing.beds != null) keyFacts.push({ label: "Beds", value: String(listing.beds) });
+  if (listing.baths != null) keyFacts.push({ label: "Baths", value: String(listing.baths) });
+  if (listing.sqft != null)
+    keyFacts.push({ label: "Sq Ft", value: listing.sqft.toLocaleString() });
+  if (listing.lot_size != null)
+    keyFacts.push({ label: "Lot Size", value: `${listing.lot_size.toLocaleString()} sqft` });
+  if (listing.rehab_level)
+    keyFacts.push({ label: "Rehab Level", value: formatStatusLabel(listing.rehab_level) });
+
+  const highlights = (listing.highlights ?? []).filter((h) => h && h.trim().length > 0);
+
+  return (
+    <div className="space-y-8">
+      <div className="overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm">
+        <div className="relative h-72 w-full sm:h-96">
+          <Image
+            src={heroSrc}
+            alt={addressLine}
+            fill
+            priority
+            sizes="(min-width: 1024px) 64rem, 100vw"
+            className="object-cover"
+          />
+        </div>
+      </div>
+
+      {photos.length > 1 ? (
+        <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
+          <h2 className="text-xl font-semibold text-slate-900">Photos</h2>
+          <p className="mt-1 text-sm text-slate-500">Tap any image for a full-size view.</p>
+          <div className="mt-6">
+            <ListingPhotoGallery photos={photos} title={addressLine} />
+          </div>
+        </div>
+      ) : photos.length === 0 ? (
+        <div className="rounded-3xl border border-dashed border-slate-200 bg-white p-8 text-center text-sm text-slate-500">
+          Additional photos coming soon.
+        </div>
+      ) : null}
+
+      {keyFacts.length > 0 ? (
+        <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
+          <h2 className="text-xl font-semibold text-slate-900">Key Facts</h2>
+          <dl className="mt-6 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {keyFacts.map((fact) => (
+              <div key={fact.label} className="border-l-2 border-slate-100 pl-4">
+                <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  {fact.label}
+                </dt>
+                <dd className="mt-1 text-lg font-semibold text-slate-900">{fact.value}</dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+      ) : null}
+
+      {listing.street_address || localeLine ? (
+        <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
+          <h2 className="text-xl font-semibold text-slate-900">Location</h2>
+          <div className="mt-4 space-y-1 text-slate-700">
+            {listing.street_address ? (
+              <p className="text-lg font-semibold">{listing.street_address}</p>
+            ) : null}
+            {localeLine ? <p className="text-sm text-slate-500">{localeLine}</p> : null}
+          </div>
+        </div>
+      ) : null}
+
+      {listing.description ? (
+        <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
+          <h2 className="text-xl font-semibold text-slate-900">About this property</h2>
+          <p className="mt-4 whitespace-pre-line text-slate-600">{listing.description}</p>
+        </div>
+      ) : null}
+
+      {highlights.length > 0 ? (
+        <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
+          <h2 className="text-xl font-semibold text-slate-900">Highlights</h2>
+          <ul className="mt-4 grid gap-3 sm:grid-cols-2">
+            {highlights.map((highlight) => (
+              <li key={highlight} className="flex items-start gap-3 text-slate-700">
+                <span
+                  aria-hidden
+                  className="mt-2 inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-zona-purple"
+                />
+                <span>{highlight}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

**Phase 5.5.b — Public Listing 3-Tab Interface + Data-Mapping Fix (CROSS-REPO, zona-desert-site part).**

Companion PR in zona-admin maps the 6 Phase 5.2.api fields the 5.5.a wave left unwired: https://github.com/vandekkers/zona-admin/pull/198

Restructures the 5.5.a single-column shell into the blueprint-locked 3-tab interface: **Overview / Bid & Buy / Deal Data**. All three panels render server-side so search engines see the full listing payload in the initial SSR HTML; a tiny client island (`ListingTabs`) toggles visibility only. Disabling JavaScript leaves the user on Overview with no broken UI.

## Blueprint Conformance

**Implements:** `Zona_Desert_Listing_Experience_v1.docx` §3 (3-tab interface) + §5 (pricing/timeline rules) + §6 (deposit) + §11 (SEO + crawlability)

**Sections addressed in this PR:**
- §3: Full 3-tab layout (Overview / Bid & Buy / Deal Data) with SSR all panels
- §5: Min bid increment ($500) + late-bid extension (10 min) + bidding closes 48h before inspection — surfaced as user-facing copy
- §6: Deposit ($250) + 3-hour deposit window — surfaced as user-facing copy
- §11: Full OG + Twitter Card meta — og:title / og:description / og:url / og:siteName / og:image / og:type / twitter:card="summary_large_image"

**Sections explicitly NOT addressed (future PRs):**
- §4: Live bid submission (5.6)
- §7: Buy Now + Stripe deposit (5.7)
- §8: Buyer auth/registration (5.9) — CTAs are honestly STUBBED, routing to `/sign-in?return=/listings&listing={slug}&action={action}`
- §9: Live bidding state / websocket pricing (5.6)
- §10: Zona Agent chatbox (5.5.c)

**Conformance delta:** Moves the public listing surface from SCAFFOLDING (5.5.a single-column shell) toward CONFORMING (3-tab interface + photo gallery + full SEO meta), with the 3 follow-up gaps explicitly enumerated.

## Spec Compliance Self-Review

**Prompt deliverables — line-by-line:**
- ✅ `app/(site)/listings/[state]/[city]/[slug]/page.tsx` — REWRITE into 3-tab layout with all panels SSR-rendered — shipped
- ✅ `components/listings/ListingTabs.tsx` — client island tab shell — shipped
- ✅ `components/listings/OverviewPanel.tsx` — gallery + description + key facts + location + highlights — shipped
- ✅ `components/listings/BidBuyPanel.tsx` — pricing + timeline + rules + stubbed CTAs — shipped
- ✅ `components/listings/DealDataPanel.tsx` — financials + cap rate + exit strategies + rehab + structure — shipped
- ⚠️ `components/listings/PhotoGallery.tsx (NEW)` — shipped with drift: reused existing `ListingPhotoGallery` instead of building duplicate (Rule 10.21 §1)
- ⚠️ `components/listings/BidCountdown.tsx (optional client island)` — shipped with drift: deferred, formatted absolute deadline shipped instead per the prompt's own qualifier (Rule 10.21 §2)
- ✅ generateMetadata extended with OG + Twitter — shipped
- ✅ `lib/types.ts` PublicListingDetail mirrors backend — shipped (already mirrored from 5.5.a; verified verbatim against companion zona-admin PR's schema)
- ✅ All tab content SSR-rendered, client toggle visibility only — shipped (`hidden` attribute, not `display: none` via class — non-active panels stay in DOM and crawlable)
- ✅ reserve_price NEVER rendered — shipped (no field path exists in the type system; privacy structurally enforced)
- ✅ Brand tokens reused via Tailwind theme — shipped
- ✅ Graceful empty states per boundary cases — shipped (no photos, no timeline, no strategies, all-null financials, terminal states)

**Scope additions (not in the prompt):** none

**Scope cuts (in the prompt, not delivered):**
- BidCountdown.tsx (deferred per prompt's own "agent's call per Rule 10.21" qualifier)

**Net result:** All deliverables shipped with 4 Rule 10.21 drift items surfaced below.

**STATUS:** DONE_WITH_CONCERNS

### Notable agent judgment (Rule 10.21 drifts)

1. **Existing `ListingPhotoGallery` REUSED** rather than building `components/listings/PhotoGallery.tsx`. Pre-write recon found the existing component already ships every feature the prompt scoped (responsive grid, lightbox modal, keyboard nav, ARIA labels). Building a sibling would have duplicated ~100 lines + fragmented the photo-display surface. Per Scar #1 + Rule 10.21, the smaller correct change is to import the existing component.
2. **`BidCountdown.tsx` deferred entirely** — prompt's own qualifier said "If complexity-prohibitive, render formatted deadline instead". A live countdown requires `setInterval` + state + race-safe unmount cleanup + tz-aware Date math — non-trivial for what is essentially a nice-to-have on top of the formatted deadline (`Intl.DateTimeFormat` with timeZoneName="short") that ships in this PR. Future PR can layer when the bidding-state websocket lands (5.6).
3. **Tab activation state lives in URL-free local React state.** Considered + rejected `?tab=` deep links via `useSearchParams` — would have forced either a server re-render per tab switch (defeats the SSR-rendered-all-panels-once goal) OR pushing all tab state into a client-only sub-tree. Local `useState` is the smaller correct mechanism; page stays deep-linkable via the canonical URL; all tab content stays in SSR HTML for crawlers.
4. **CTAs route to `/sign-in?return=/listings&listing={slug}&action={action}`** rather than the full nested URL. Forward-compatible contract for the 5.9 buyer auth UI — resolves back to the exact listing via the slug + pre-selects the action without state/city slug variant ambiguity.

## Pre-merge checklist

- [x] Prompt cited Phase 5.5.b sub-wave (companion to zona-admin PR #198)
- [x] PR body has Blueprint Conformance + Spec Compliance Self-Review + STATUS line
- [x] `npm run lint` clean
- [x] `npm run build` succeeds — `/listings/[state]/[city]/[slug]` 1.9 kB / 103 kB First Load JS
- [x] `reserve_price` has no rendering path (privacy structurally enforced)
- [x] All tab content in SSR HTML (crawlable via `hidden` attribute)

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` clean
- [ ] Visual verification on Vercel preview after merge — verify 3 tabs render and tab toggle works
- [ ] Mobile responsive verification on Vercel preview
- [ ] Verify OG meta in Vercel preview's `<head>` (View Source)

🤖 Generated with [Claude Code](https://claude.com/claude-code)