### PR TITLE
fix(images): whitelist S3 hosts for listing photos (Phase 5.5.fix)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,20 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true
+  reactStrictMode: true,
+  images: {
+    // Phase 5.5.fix — production listing photos are uploaded to S3 via
+    // app/services/aws.py on the backend ({bucket}.s3.{region}.amazonaws.com).
+    // Without this whitelist, next/image rejects every external host with a
+    // server-side 500 — the 5.5.b listing detail page crashed the moment a
+    // listing carried photos. ** matches multi-level subdomains so any
+    // bucket/region combination resolves cleanly.
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "**.amazonaws.com"
+      }
+    ]
+  }
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary

**Phase 5.5.fix — frontend half of cross-repo fix-pack.**

`next.config.mjs` had ZERO `images` config. Without `images.remotePatterns`, `next/image` rejects EVERY external photo host with a server-side 500.

Verified live during guided visual verification: the 5.5.b listing detail page crashed the moment a listing carried photos. Console:

```
Error: Invalid src prop (...) hostname "..." is not configured under images in your next.config.js
```

Production listing photos are uploaded to S3 via `app/services/aws.py` on the backend, producing URLs of form `{bucket}.s3.{region}.amazonaws.com`. The `**.amazonaws.com` wildcard covers any bucket + region combination cleanly with one entry — no per-bucket config required for staging/prod swap.

Paired with zona-admin `fix/phase-5-5-fix-pack` (`_as_card` city/state mapping) — both ship together.

## Spec Compliance Self-Review

**Prompt deliverables — line-by-line:**
- ✅ `images.remotePatterns` whitelist `**.amazonaws.com` (https) — shipped
- ✅ `reactStrictMode: true` preserved — shipped (existing line untouched)
- ✅ Nothing else in `next.config.mjs` touched — shipped (only the `images` block added)
- ✅ `middleware.ts` UNTOUCHED — shipped (verified via `git diff`)
- ✅ Conventional commit + branch — shipped (branch `fix/phase-5-5-fix-pack`)

**Scope additions (not in the prompt):** none
**Scope cuts (in the prompt, not delivered):** none
**Net result:** all deliverables shipped clean

## Verified facts (pre-write recon per Scar #24)

- Pre-fix `next.config.mjs` verbatim: `{ reactStrictMode: true }` only — NO `images` config
- Backend S3 upload service: `app/services/aws.py` (zona-admin) produces `{bucket}.s3.{region}.amazonaws.com` URLs
- Next.js `remotePatterns` `**` syntax: valid glob — matches multi-level subdomains per [Next.js Image config docs](https://nextjs.org/docs/app/api-reference/components/image#remotepatterns)
- `middleware.ts`: untouched per Scar #34 — verified via `git diff`
- No new deps, no other file mods

## Rule 10.21 override §1 (Scar #34 surfacing): `**.amazonaws.com` wildcard rather than per-bucket entries

Per-bucket entries would require updating frontend config every time a backend env changes a bucket name (staging vs prod vs dev all use different buckets). The wildcard widens trust to "all S3 buckets" — not "any host" — and matches the backend's environment-configurable bucket pattern. Non-S3 hosts (e.g., the optional `FILE_BASE_URL` CDN override in `aws.py`) still get rejected by `next/image` if/when configured — adding them is an env-specific follow-on.

## Tests + checks

- `npm run lint`: clean (zero new warnings; pre-existing warnings in unrelated files unchanged)
- `npm run build`: compiled successfully (`✓ Compiled successfully` confirmed; type-check phase completes per `npx tsc --noEmit` exit 0)
- `npx tsc --noEmit`: clean (exit 0, no type errors)
- No new dependencies

## DO NOT TOUCH

- `middleware.ts` (owner gate) — untouched
- Everything else in `next.config.mjs` — untouched
- Other site routes — untouched

## Test plan

- [ ] Vercel preview build succeeds
- [ ] Listing detail page renders photos without 500 (manual smoke test on a seeded listing with photos)
- [ ] Vercel image optimization picks up the new remote pattern (no `Invalid src prop` errors)

**STATUS:** DONE

🤖 Generated with [Claude Code](https://claude.com/claude-code)