### PR TITLE
feat(listings): Zona Agent chat widget (Phase 5.5.c)

### DIFF
--- a/app/(site)/listings/[state]/[city]/[slug]/page.tsx
+++ b/app/(site)/listings/[state]/[city]/[slug]/page.tsx
@@ -1,10 +1,19 @@
 import Image from "next/image";
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import dynamic from "next/dynamic";
 import type { Metadata } from "next";
 
 import { fetchPublicListing } from "@/lib/publicApi";
 import type { PublicListingDetail } from "@/lib/types";
+
+// Phase 5.5.c — Zona Agent chat widget mounts as a client-only island.
+// Dynamic import with ssr:false keeps the SSR HTML free of the chat
+// bundle so marketing surfaces (status, hero, pricing) are never
+// blocked by it. Widget failure NEVER breaks the listing page.
+const ZonaAgentChat = dynamic(() => import("@/components/ZonaAgentChat"), {
+  ssr: false
+});
 
 // Phase 5.5.a — Public Listing Foundation.
 //
@@ -181,6 +190,8 @@ export default async function PublicListingDetailPage({ params }: PageProps) {
           <p className="mt-4 whitespace-pre-line text-slate-600">{listing.description}</p>
         </div>
       ) : null}
+
+      <ZonaAgentChat slug={params.slug} listingLabel={addressLine} />
     </div>
   );
 }

--- a/components/ZonaAgentChat.tsx
+++ b/components/ZonaAgentChat.tsx
@@ -1,0 +1,338 @@
+"use client";
+
+// Phase 5.5.c — Zona Agent client island.
+//
+// Floating launcher (bottom-right) → chat panel (mobile: full-width
+// bottom sheet). Stateless V1 — full conversation history kept in
+// component state and sent to the backend on every turn. No persistence,
+// no streaming.
+//
+// Failure surfacing matches the backend contract:
+//   503 agent_offline → "The agent is offline right now — try the
+//                        Bid & Buy tab or contact us."
+//   502 agent_unavailable → "The Zona Agent ran into an issue. Try
+//                            again in a moment."
+//   429              → "Lots of questions right now — one moment."
+//   404 / 422 / net   → generic retry copy.
+//
+// SSR safety: this component is "use client" but the listing detail
+// page mounts it via a dynamic import with ssr:false so the server-
+// rendered marketing surface (status badge, hero, pricing) is never
+// blocked by the chat bundle.
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import {
+  ZonaAgentChatError,
+  sendListingChat
+} from "@/lib/publicApi";
+import type {
+  ZonaAgentChatErrorKind,
+  ZonaAgentChatMessage
+} from "@/lib/types";
+
+// Per-message cap mirrors the backend ``MAX_CHARS_PER_MESSAGE`` from
+// app/schemas/public_chat.py — surfaced here so the textarea can
+// hard-stop input before a 422 round-trip.
+const MAX_CHARS_PER_MESSAGE = 1000;
+
+interface ZonaAgentChatProps {
+  slug: string;
+  listingLabel: string;
+}
+
+interface DisplayMessage extends ZonaAgentChatMessage {
+  /** Stable client-side id for React keys. */
+  id: string;
+  /** When true, the assistant content is the "typing…" placeholder. */
+  typing?: boolean;
+}
+
+const WELCOME_TEXT =
+  "Hi! I'm the Zona Agent. Ask me anything about this listing — beds and baths, exit strategies, financials, or how the Bid & Buy flow works.";
+
+function makeId(): string {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function errorCopy(kind: ZonaAgentChatErrorKind): string {
+  switch (kind) {
+    case "offline":
+      return "The Zona Agent is offline right now. Try the Bid & Buy tab or use Contact Us for help.";
+    case "rate_limited":
+      return "Lots of questions right now — please try again in a moment.";
+    case "validation":
+      return "That message didn't make it through. Try shortening it and send again.";
+    case "not_found":
+      return "This listing isn't available for chat right now.";
+    case "network":
+      return "Connection hiccup. Check your network and try again.";
+    case "unavailable":
+    default:
+      return "The Zona Agent ran into an issue. Try again in a moment.";
+  }
+}
+
+export default function ZonaAgentChat({ slug, listingLabel }: ZonaAgentChatProps) {
+  const [open, setOpen] = useState(false);
+  const [messages, setMessages] = useState<DisplayMessage[]>([
+    { id: "welcome", role: "assistant", content: WELCOME_TEXT }
+  ]);
+  const [input, setInput] = useState("");
+  const [sending, setSending] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const messagesEndRef = useRef<HTMLDivElement | null>(null);
+  const inputRef = useRef<HTMLTextAreaElement | null>(null);
+
+  // Scroll to bottom on every new message so the user always sees the
+  // latest reply. Guarded with optional chaining so SSR + initial
+  // render (when ref is null) stay safe.
+  useEffect(() => {
+    if (open) {
+      messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+    }
+  }, [messages, open]);
+
+  // Focus the textarea when the panel opens so the user can start
+  // typing immediately.
+  useEffect(() => {
+    if (open) {
+      const timer = setTimeout(() => {
+        inputRef.current?.focus();
+      }, 50);
+      return () => clearTimeout(timer);
+    }
+    return undefined;
+  }, [open]);
+
+  // ESC closes the panel (when not actively sending).
+  useEffect(() => {
+    if (!open) return undefined;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !sending) {
+        setOpen(false);
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [open, sending]);
+
+  // Wire history → backend on send.
+  const handleSend = useCallback(async () => {
+    const trimmed = input.trim();
+    if (!trimmed || sending) return;
+
+    setErrorMessage(null);
+
+    const userMsg: DisplayMessage = {
+      id: makeId(),
+      role: "user",
+      content: trimmed
+    };
+    const typingMsg: DisplayMessage = {
+      id: "typing",
+      role: "assistant",
+      content: "Zona Agent is typing…",
+      typing: true
+    };
+
+    // Append optimistically so the conversation feels responsive.
+    setMessages((prev) => [...prev, userMsg, typingMsg]);
+    setInput("");
+    setSending(true);
+
+    // Build the wire payload from the durable history (welcome + prior
+    // turns + new user message). The "typing" placeholder is never
+    // sent; the backend cap is per-CONTENT length so it must not
+    // appear in the payload either.
+    const wireMessages: ZonaAgentChatMessage[] = [
+      ...messages
+        .filter((m) => !m.typing && m.id !== "welcome")
+        .map((m) => ({ role: m.role, content: m.content })),
+      { role: "user", content: trimmed }
+    ];
+
+    try {
+      const { reply } = await sendListingChat(slug, wireMessages);
+      setMessages((prev) =>
+        prev
+          .filter((m) => m.id !== "typing")
+          .concat({ id: makeId(), role: "assistant", content: reply })
+      );
+    } catch (err) {
+      const chatErr =
+        err instanceof ZonaAgentChatError
+          ? err
+          : new ZonaAgentChatError("unavailable", "unknown error");
+      setMessages((prev) => prev.filter((m) => m.id !== "typing"));
+      setErrorMessage(errorCopy(chatErr.kind));
+    } finally {
+      setSending(false);
+    }
+  }, [input, messages, sending, slug]);
+
+  // Enter to send, Shift+Enter for newline.
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        void handleSend();
+      }
+    },
+    [handleSend]
+  );
+
+  const charCount = input.length;
+  const overLimit = charCount > MAX_CHARS_PER_MESSAGE;
+
+  const launcherLabel = useMemo(
+    () => `Ask the Zona Agent about ${listingLabel}`,
+    [listingLabel]
+  );
+
+  return (
+    <>
+      {/* Floating launcher */}
+      {!open ? (
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          aria-label={launcherLabel}
+          className="fixed bottom-6 right-6 z-40 flex items-center gap-2 rounded-full bg-zona-purple px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-zona-purple/30 transition hover:bg-zona-purple-deep focus:outline-none focus:ring-2 focus:ring-zona-purple focus:ring-offset-2"
+        >
+          <svg
+            aria-hidden="true"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={2}
+            stroke="currentColor"
+            className="h-5 w-5"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M8 10h.01M12 10h.01M16 10h.01M21 12c0 4.418-4.03 8-9 8a9.86 9.86 0 0 1-4.255-.949L3 20l1.39-3.687A7.94 7.94 0 0 1 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8Z"
+            />
+          </svg>
+          <span>Ask Zona Agent</span>
+        </button>
+      ) : null}
+
+      {/* Chat panel */}
+      {open ? (
+        <div
+          ref={panelRef}
+          role="dialog"
+          aria-modal="false"
+          aria-label="Zona Agent chat"
+          className="fixed bottom-0 right-0 z-50 flex h-[80vh] w-full flex-col rounded-t-3xl border border-slate-200 bg-white shadow-2xl sm:bottom-6 sm:right-6 sm:h-[32rem] sm:w-[26rem] sm:rounded-3xl"
+        >
+          {/* Header */}
+          <header className="flex items-center justify-between rounded-t-3xl bg-zona-purple px-5 py-3 text-white">
+            <div className="flex items-center gap-2">
+              <span
+                aria-hidden="true"
+                className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-white/15 text-sm font-bold"
+              >
+                Z
+              </span>
+              <div>
+                <p
+                  className="text-sm font-semibold leading-tight"
+                  style={{ fontFamily: "var(--font-sora, 'Sora', sans-serif)" }}
+                >
+                  Zona Agent
+                </p>
+                <p className="text-xs text-white/80">Listing assistant</p>
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={() => setOpen(false)}
+              aria-label="Close chat"
+              className="rounded-full p-1.5 text-white/90 transition hover:bg-white/15 focus:outline-none focus:ring-2 focus:ring-white"
+            >
+              <svg
+                aria-hidden="true"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={2}
+                stroke="currentColor"
+                className="h-4 w-4"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </header>
+
+          {/* Messages */}
+          <div
+            className="flex-1 space-y-3 overflow-y-auto px-4 py-3"
+            style={{ fontFamily: "var(--font-inter, 'Inter', sans-serif)" }}
+          >
+            {messages.map((msg) => (
+              <div
+                key={msg.id}
+                className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}
+              >
+                <div
+                  className={
+                    msg.role === "user"
+                      ? "max-w-[85%] rounded-2xl rounded-br-sm bg-zona-purple px-4 py-2 text-sm text-white"
+                      : msg.typing
+                        ? "max-w-[85%] rounded-2xl rounded-bl-sm bg-slate-100 px-4 py-2 text-sm italic text-slate-500"
+                        : "max-w-[85%] whitespace-pre-line rounded-2xl rounded-bl-sm bg-slate-100 px-4 py-2 text-sm text-slate-900"
+                  }
+                >
+                  {msg.content}
+                </div>
+              </div>
+            ))}
+            {errorMessage ? (
+              <div role="alert" className="rounded-xl bg-zona-amber/15 px-3 py-2 text-xs font-semibold text-zona-navy">
+                {errorMessage}
+              </div>
+            ) : null}
+            <div ref={messagesEndRef} />
+          </div>
+
+          {/* Composer */}
+          <div className="border-t border-slate-200 p-3">
+            <div className="flex items-end gap-2">
+              <textarea
+                ref={inputRef}
+                value={input}
+                onChange={(e) => setInput(e.target.value.slice(0, MAX_CHARS_PER_MESSAGE))}
+                onKeyDown={handleKeyDown}
+                placeholder="Ask about this listing…"
+                rows={2}
+                disabled={sending}
+                aria-label="Type your message"
+                className="flex-1 resize-none rounded-2xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-zona-purple focus:bg-white focus:outline-none focus:ring-2 focus:ring-zona-purple/40 disabled:opacity-60"
+                style={{ fontFamily: "var(--font-inter, 'Inter', sans-serif)" }}
+              />
+              <button
+                type="button"
+                onClick={() => void handleSend()}
+                disabled={sending || input.trim().length === 0 || overLimit}
+                aria-label="Send message"
+                className="rounded-full bg-zona-purple px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-zona-purple-deep disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {sending ? "…" : "Send"}
+              </button>
+            </div>
+            <p className="mt-1.5 text-[11px] text-slate-500">
+              {sending
+                ? "Sending…"
+                : `${charCount}/${MAX_CHARS_PER_MESSAGE} characters. Enter to send · Shift+Enter for newline`}
+            </p>
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/lib/publicApi.ts
+++ b/lib/publicApi.ts
@@ -9,7 +9,10 @@ import {
   PublicListingDetail,
   PublicOfferResponse,
   SellerLeadPayload,
-  WholesalerIntakePayload
+  WholesalerIntakePayload,
+  ZonaAgentChatErrorKind,
+  ZonaAgentChatMessage,
+  ZonaAgentChatReply
 } from "./types";
 
 export class PublicApiError extends Error {
@@ -429,4 +432,71 @@ export async function fetchPublicListing(
     throw new PublicApiError(`Failed to fetch listing: ${res.status}`, res.status);
   }
   return res.json();
+}
+
+// ---------------------------------------------------------------------------
+// Zona Agent public listing chat (Phase 5.5.c)
+//
+// POST /public/listings/{slug}/chat — stateless, client-held history.
+// Backend caps: ≤12 messages, ≤1,000 chars per message, ≤8,000 total
+// (Pydantic schema layer). Per-IP rate limit 10/min (PR #200 limiter).
+//
+// Error classification: ZonaAgentChatError carries a typed ``kind`` the
+// widget reads to render state-specific copy. 503 → offline, 502 →
+// unavailable, 429 → rate_limited. Backend never returns raw 500;
+// network/parse failures bubble up as kind="network".
+// ---------------------------------------------------------------------------
+
+export class ZonaAgentChatError extends Error {
+  kind: ZonaAgentChatErrorKind;
+  status?: number;
+
+  constructor(kind: ZonaAgentChatErrorKind, message: string, status?: number) {
+    super(message);
+    this.kind = kind;
+    this.status = status;
+  }
+}
+
+function classifyChatStatus(status: number): ZonaAgentChatErrorKind {
+  if (status === 503) return "offline";
+  if (status === 502) return "unavailable";
+  if (status === 429) return "rate_limited";
+  if (status === 404) return "not_found";
+  if (status === 422) return "validation";
+  return "unavailable";
+}
+
+export async function sendListingChat(
+  slug: string,
+  messages: ZonaAgentChatMessage[]
+): Promise<ZonaAgentChatReply> {
+  let res: Response;
+  try {
+    res = await fetch(
+      `${API_BASE_URL}/public/listings/${encodeURIComponent(slug)}/chat`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        cache: "no-store",
+        body: JSON.stringify({ messages })
+      }
+    );
+  } catch (err) {
+    throw new ZonaAgentChatError("network", err instanceof Error ? err.message : "network");
+  }
+
+  if (!res.ok) {
+    throw new ZonaAgentChatError(
+      classifyChatStatus(res.status),
+      `chat request failed: ${res.status}`,
+      res.status
+    );
+  }
+
+  try {
+    return (await res.json()) as ZonaAgentChatReply;
+  } catch {
+    throw new ZonaAgentChatError("unavailable", "malformed reply", res.status);
+  }
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -320,3 +320,43 @@ export interface PublicListingCollection {
   page: number;
   page_size: number;
 }
+
+// ---------------------------------------------------------------------------
+// Zona Agent public listing chat (Phase 5.5.c)
+//
+// Stateless V1 — client holds full conversation history in component
+// state and sends it with each POST to /public/listings/{slug}/chat.
+// snake_case keys mirror the backend schemas at
+// apps/api/app/schemas/public_chat.py per Scar #24 pre-write recon.
+//
+// Caps enforced server-side via Pydantic (≤12 messages, ≤1,000 chars
+// per message, ≤8,000 total). The frontend mirrors the per-message
+// cap to surface the limit early in the textarea UX.
+// ---------------------------------------------------------------------------
+
+export type ZonaAgentChatRole = "user" | "assistant";
+
+export interface ZonaAgentChatMessage {
+  role: ZonaAgentChatRole;
+  content: string;
+}
+
+export interface ZonaAgentChatRequest {
+  messages: ZonaAgentChatMessage[];
+}
+
+export interface ZonaAgentChatReply {
+  reply: string;
+}
+
+// Frontend-only error class returned to the widget so it can render
+// state-specific copy (offline / overloaded / unavailable). The backend
+// surfaces 503/502/429 detail strings verbatim; the widget maps these
+// to friendly messages.
+export type ZonaAgentChatErrorKind =
+  | "offline"        // 503 agent_offline — no provider configured
+  | "unavailable"    // 502 agent_unavailable — upstream provider error
+  | "rate_limited"   // 429 — too many requests for this IP
+  | "not_found"      // 404 — listing not visible
+  | "validation"     // 422 — schema cap violation
+  | "network";       // fetch failed locally


### PR DESCRIPTION
## Summary

Final Phase 5.5 slice — Zona Agent chatbox client island on every public listing detail page. Mounts via `dynamic(..., { ssr: false })` so the SSR marketing surface (status badge, hero, pricing, key facts, description) stays crawlable and is NEVER blocked by the chat bundle. Stateless V1 — client holds full conversation history in `useState` and POSTs it with each turn to the paired zona-admin endpoint.

Floating brand-purple launcher (bottom-right) opens a rounded chat panel (mobile: full-width bottom sheet, desktop: 26rem × 32rem). Friendly state-mapped error states for 503/502/429/404/422/network.

Pairs with zona-admin PR #203 — that PR holds the privacy-bounded backend that builds the system prompt SERVER-SIDE exclusively from the REDUCED public DTO.

## Spec Compliance Self-Review

**Prompt deliverables — line-by-line:**
- ✅ `components/ZonaAgentChat.tsx` (NEW client island) — shipped (~270 lines, floating launcher → panel, brand tokens, ARIA, ESC, Enter-to-send)
- ✅ Detail `page.tsx` (EDIT — mount) — shipped (`dynamic(..., { ssr: false })` + mount as last child of outer container; existing SSR shell UNTOUCHED structurally)
- ✅ `lib/publicApi.ts` (EDIT — APPEND `sendListingChat`) — shipped (with `ZonaAgentChatError` class + `classifyChatStatus` status→kind mapping)
- ✅ Brand tokens only (Tailwind zona-purple family) — verified verbatim against `tailwind.config.ts` inventory (zona-purple-deep / zona-purple / zona-orange / zona-amber / zona-navy / zona-off-white)
- ✅ Sora for panel title, Inter for messages — shipped via CSS variables `var(--font-sora)` / `var(--font-inter)`
- ✅ Page stays SSR — chat widget client island, dynamic import with `ssr:false`; SSR shell does not block on widget bundle
- ✅ Friendly error states for 429 / 503 / 502 — shipped via `errorCopy(kind)` switch
- ✅ "Zona Agent is typing…" loading state — shipped (optimistic UI placeholder, replaced on success)
- ✅ History in component state — shipped (no persistence; matches backend stateless V1)

**Scope additions (not in the prompt):** 6 `ZonaAgentChatErrorKind` literal-union types in `lib/types.ts` (offline/unavailable/rate_limited/not_found/validation/network) for state-specific UI copy. Cleaner than ad-hoc message strings; types stay in sync with backend status codes via `classifyChatStatus`.

**Scope cuts (in the prompt, not delivered):** none.

**Net result:** all deliverables shipped clean. No drift items.

**STATUS:** DONE

## Notable agent judgment (Rule 10.21)

### Frontend brand color recon (Scar #24 verbatim copy)
Pre-write recon verified `tailwind.config.ts` brand tokens before any classes authored. Confirmed 6 zona-* colors: purple-deep (#4A1988), purple-mid + purple alias (#7025B6), orange, amber, navy, off-white. NO green token — reliability "high" / launcher button reuses `zona-purple` per the same no-green discipline documented in the AGENTS.md scar history for the 4.4.m / 5.1.ui / 5.3.ui PRs.

### Dynamic-import with `ssr:false` placement
Mounting the widget at the END of the page outer container (not nested inside any of the existing card divs) keeps the dynamic boundary clean — the SSR `<div>` shell + back-link + status badge + hero + pricing + key facts + description card all render server-side independently. The widget code-splits on demand. Page bundle 4.78 kB / 106 kB First Load JS (up from 1.9 kB / 103 kB 5.5.a baseline due to the widget; budget acceptable for a public AI surface).

## Blueprint Conformance

**Implements:** `Zona_Desert_Site_Restructure_Blueprint_v1.docx` + `Zona_Desert_Listing_Experience_v1.docx` — "Zona Agent AI chatbox on every listing" frontend slice.

**Sections addressed in this PR:**
- Zona Agent chatbox visible + functional on every public listing detail page
- Friendly offline + rate-limit + error states (no raw status codes leak to UI)
- Brand-aligned launcher + panel matching DESIGN.md §6 brand tokens
- ARIA-compliant dialog + alert + label patterns

**Sections explicitly NOT addressed (future PRs):**
- Chat persistence + cross-session resume — V1 stateless
- Streaming token-by-token UX — V1 single JSON reply
- Mobile chatbox-as-fullscreen-route — V1 bottom sheet

**Conformance delta:** Zona Agent chatbox lands CONFORMING for V1 visual + interaction contract. Full persistence + streaming UX deferred to follow-on slices.

## Blueprint Conformance Verdict

**Blueprint implemented:** Site Restructure + Listing Experience — Zona Agent chatbox frontend

**Sections truly addressed by this PR:**
1. Brand-aligned floating launcher + chat panel
2. Stateless client-held history with optimistic UI
3. Backend-status-driven friendly error states
4. SSR-safe mount preserving page crawlability

**Sections claimed but NOT fully addressed:** none.

**Honest status after this PR:** CONFORMING for V1 visual + interaction contract.

**What still remains for full module CONFORMING:**
- Streaming UX
- Persistence + resume on revisit
- Optional mobile fullscreen route

## Test plan
- [x] `npm run lint` — clean, zero warnings/errors
- [x] `npm run build` — clean; `/listings/[state]/[city]/[slug]` bundle 4.78 kB / 106 kB First Load JS
- [ ] Vercel preview — verify launcher renders, panel opens, error states surface friendly copy when backend returns 503 (no ANTHROPIC_API_KEY in staging)
- [ ] Visual verification — launcher + panel against DESIGN.md §6 brand tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)