### PR TITLE
feat(deals): GitHub gateway — edit, publish, delete deals from /deal-desk

### DIFF
--- a/DEALS_BREAKAWAY.md
+++ b/DEALS_BREAKAWAY.md
@@ -10,7 +10,7 @@ find every trace.
 
 | Path | What it is |
 |---|---|
-| `app/(deals)/` | The whole route group: board, deal pages, `/deal-desk`, layout, components, math lib |
+| `app/(deals)/` | The whole route group: board, deal pages, `/deal-desk`, the `/api/deals-admin` GitHub gateway, layout, components, math lib |
 | `content/deals/` | One JSON file per deal, plus `_SCHEMA.json` and `_TEMPLATE.json` |
 | `content/deals-config.json` | Phone / email / headline / repo config |
 | `content/DEALS_README.md` | The founder's plain-English instructions |
@@ -19,6 +19,12 @@ find every trace.
 
 (JSON files cannot carry code comments; `deals-config.json` and `_SCHEMA.json`
 carry a `$comment` breakaway note inside their data instead of a `//` marker.)
+
+## Also remove from Vercel
+
+- The `GITHUB_DEALS_TOKEN` environment variable (Production scope) — the
+  deal-desk publishing gateway's GitHub credential. Revoke the fine-grained
+  PAT itself at github.com → Settings → Developer settings while you're at it.
 
 ## Restore the marked lines in `middleware.ts`
 

--- a/app/(deals)/_components/DealDeskForm.tsx
+++ b/app/(deals)/_components/DealDeskForm.tsx
@@ -2,22 +2,48 @@
 
 // BREAKAWAY: deals board — remove at platform launch
 //
-// Owner deal builder. Two modes:
+// Owner deal cockpit. Three capabilities:
+//  - Manage: every live deal listed with one-click edit / delete
 //  - Build: form fields → live underwriting preview → deal JSON
 //  - Paste: validate JSON produced elsewhere (e.g. by an AI assistant
 //    following content/deals/_SCHEMA.json)
-// Output actions are zero-backend: copy the JSON, or open GitHub's
-// new-file page prefilled with filename + content and commit there.
+// Publishing goes through /api/deals-admin (the GitHub gateway) when a
+// GITHUB_DEALS_TOKEN is configured in Vercel; otherwise it falls back to
+// prefilled GitHub web-UI links. Fields the form doesn't manage (comps,
+// financing overrides, expense-% overrides…) are carried through
+// untouched when editing an existing deal.
 
 import { useMemo, useState } from "react";
 import type { Deal, DealsConfig } from "../_lib/deal-shared";
-import { flipMath, money, rentalMath } from "../_lib/deal-shared";
+import { flipMath, money, rentalMath, validateDeal } from "../_lib/deal-shared";
 
 const input =
   "w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-zona-purple-mid";
 const label = "block text-xs font-semibold uppercase tracking-wide text-slate-500 mb-1";
 const section = "rounded-3xl border border-slate-200 bg-white p-5 space-y-4";
 const heading = "text-sm font-semibold text-zona-navy";
+
+const MANAGED_TOP_KEYS = [
+  "id", "status", "strategy", "address", "city", "state", "zip", "price", "arv",
+  "estRehab", "beds", "baths", "sqft", "lotSqft", "yearBuilt", "propertyType",
+  "occupancy", "description", "highlights", "photos", "rental", "terms",
+  "closeBy", "featured"
+] as const;
+const MANAGED_RENTAL_KEYS = [
+  "monthlyRent", "taxesAnnual", "insuranceAnnual", "hoaMonthly", "section8"
+] as const;
+const MANAGED_TERMS_KEYS = ["emd", "closeMethod", "access"] as const;
+
+function omit(
+  source: Record<string, unknown>,
+  keys: readonly string[]
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(source)) {
+    if (!keys.includes(key)) out[key] = value;
+  }
+  return out;
+}
 
 function slugify(value: string): string {
   return value
@@ -31,44 +57,26 @@ function num(value: string): number {
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
-// Lightweight mirror of content/deals/_SCHEMA.json for instant feedback.
-function validateDeal(candidate: unknown): string[] {
-  const errors: string[] = [];
-  if (typeof candidate !== "object" || candidate === null) return ["Not a JSON object."];
-  const d = candidate as Record<string, unknown>;
-  const requireString = (key: string) => {
-    if (typeof d[key] !== "string" || (d[key] as string).length === 0)
-      errors.push(`"${key}" is required (text).`);
-  };
-  const requireNumber = (key: string, min = 0) => {
-    if (typeof d[key] !== "number" || (d[key] as number) < min)
-      errors.push(`"${key}" is required (number ≥ ${min}).`);
-  };
-  ["id", "address", "city", "state", "zip", "description"].forEach(requireString);
-  ["arv", "estRehab", "beds", "baths", "lotSqft", "yearBuilt"].forEach((k) => requireNumber(k));
-  ["price", "sqft"].forEach((k) => {
-    if (typeof d[k] !== "number" || (d[k] as number) <= 0)
-      errors.push(`"${k}" is required (number > 0).`);
-  });
-  if (typeof d.id === "string" && !/^[a-z0-9]+(-[a-z0-9]+)*$/.test(d.id))
-    errors.push('"id" must be lowercase letters/numbers with hyphens (e.g. 123-main-st).');
-  if (typeof d.state === "string" && !/^[A-Z]{2}$/.test(d.state))
-    errors.push('"state" must be a 2-letter code like MI.');
-  if (typeof d.zip === "string" && !/^\d{5}$/.test(d.zip))
-    errors.push('"zip" must be 5 digits.');
-  if (!["available", "pending", "sold"].includes(d.status as string))
-    errors.push('"status" must be available, pending, or sold.');
-  if (!Array.isArray(d.photos) || d.photos.length === 0)
-    errors.push('"photos" needs at least one path or URL.');
-  if (!Array.isArray(d.highlights)) errors.push('"highlights" must be a list of strings.');
-  const rental = d.rental as Record<string, unknown> | undefined;
-  if (rental && (typeof rental.monthlyRent !== "number" || rental.monthlyRent <= 0))
-    errors.push('"rental.monthlyRent" must be a number > 0 when a rental block is present.');
-  return errors;
+type ShipState =
+  | { status: "idle" }
+  | { status: "working" }
+  | { status: "done"; message: string; id: string }
+  | { status: "error"; message: string };
+
+interface Props {
+  config: DealsConfig;
+  deals: Deal[];
+  gatewayReady: boolean;
 }
 
-export function DealDeskForm({ config }: { config: DealsConfig }) {
+export function DealDeskForm({ config, deals, gatewayReady }: Props) {
   const [mode, setMode] = useState<"build" | "paste">("build");
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [extras, setExtras] = useState<Record<string, unknown>>({});
+  const [rentalExtras, setRentalExtras] = useState<Record<string, unknown>>({});
+  const [termsExtras, setTermsExtras] = useState<Record<string, unknown>>({});
+  const [ship, setShip] = useState<ShipState>({ status: "idle" });
+  const [deletingId, setDeletingId] = useState<string | null>(null);
 
   // Basics
   const [address, setAddress] = useState("");
@@ -112,7 +120,73 @@ export function DealDeskForm({ config }: { config: DealsConfig }) {
   const [pasted, setPasted] = useState("");
   const [copied, setCopied] = useState(false);
 
-  const id = slugify(address);
+  const id = editingId && slugify(address) === editingId ? editingId : slugify(address);
+
+  function clearForm() {
+    setEditingId(null);
+    setExtras({});
+    setRentalExtras({});
+    setTermsExtras({});
+    setAddress(""); setCity("Detroit"); setStateCode("MI"); setZip("");
+    setStatus("available"); setIsRental(true); setIsFlip(true); setFeatured(false);
+    setCloseBy(""); setPropertyType("Single Family"); setOccupancy("Vacant");
+    setPrice(""); setArv(""); setEstRehab(""); setBeds(""); setBaths("");
+    setSqft(""); setLotSqft(""); setYearBuilt("");
+    setMonthlyRent(""); setTaxesAnnual(""); setInsuranceAnnual(""); setHoaMonthly("");
+    setSection8(false); setEmd(""); setCloseMethod("Assignment"); setAccess("");
+    setDescription(""); setHighlightsText(""); setPhotosText("");
+    setShip({ status: "idle" });
+  }
+
+  function loadDeal(deal: Deal) {
+    const raw = deal as unknown as Record<string, unknown>;
+    setMode("build");
+    setEditingId(deal.id);
+    setExtras(omit(raw, MANAGED_TOP_KEYS));
+    setRentalExtras(
+      deal.rental
+        ? omit(deal.rental as unknown as Record<string, unknown>, MANAGED_RENTAL_KEYS)
+        : {}
+    );
+    setTermsExtras(
+      deal.terms
+        ? omit(deal.terms as unknown as Record<string, unknown>, MANAGED_TERMS_KEYS)
+        : {}
+    );
+    setAddress(deal.address);
+    setCity(deal.city);
+    setStateCode(deal.state);
+    setZip(deal.zip);
+    setStatus(deal.status);
+    const strategies = deal.strategy ?? (deal.rental ? ["rental", "flip"] : ["flip"]);
+    setIsRental(strategies.includes("rental"));
+    setIsFlip(strategies.includes("flip"));
+    setFeatured(Boolean(deal.featured));
+    setCloseBy(deal.closeBy ?? "");
+    setPropertyType(deal.propertyType ?? "");
+    setOccupancy(deal.occupancy ?? "");
+    setPrice(String(deal.price));
+    setArv(String(deal.arv));
+    setEstRehab(String(deal.estRehab));
+    setBeds(String(deal.beds));
+    setBaths(String(deal.baths));
+    setSqft(String(deal.sqft));
+    setLotSqft(String(deal.lotSqft));
+    setYearBuilt(String(deal.yearBuilt));
+    setMonthlyRent(deal.rental ? String(deal.rental.monthlyRent) : "");
+    setTaxesAnnual(deal.rental?.taxesAnnual ? String(deal.rental.taxesAnnual) : "");
+    setInsuranceAnnual(deal.rental?.insuranceAnnual ? String(deal.rental.insuranceAnnual) : "");
+    setHoaMonthly(deal.rental?.hoaMonthly ? String(deal.rental.hoaMonthly) : "");
+    setSection8(Boolean(deal.rental?.section8));
+    setEmd(deal.terms?.emd ? String(deal.terms.emd) : "");
+    setCloseMethod(deal.terms?.closeMethod ?? "");
+    setAccess(deal.terms?.access ?? "");
+    setDescription(deal.description);
+    setHighlightsText(deal.highlights.join("\n"));
+    setPhotosText(deal.photos.join("\n"));
+    setShip({ status: "idle" });
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  }
 
   const builtDeal = useMemo(() => {
     const strategy: string[] = [
@@ -120,6 +194,7 @@ export function DealDeskForm({ config }: { config: DealsConfig }) {
       ...(isFlip ? ["flip"] : [])
     ];
     const deal: Record<string, unknown> = {
+      ...extras,
       id,
       status,
       ...(strategy.length > 0 ? { strategy } : {}),
@@ -149,6 +224,7 @@ export function DealDeskForm({ config }: { config: DealsConfig }) {
     };
     if (isRental && num(monthlyRent) > 0) {
       deal.rental = {
+        ...rentalExtras,
         monthlyRent: num(monthlyRent),
         ...(num(taxesAnnual) > 0 ? { taxesAnnual: num(taxesAnnual) } : {}),
         ...(num(insuranceAnnual) > 0 ? { insuranceAnnual: num(insuranceAnnual) } : {}),
@@ -156,8 +232,14 @@ export function DealDeskForm({ config }: { config: DealsConfig }) {
         ...(section8 ? { section8: true } : {})
       };
     }
-    if (num(emd) > 0 || closeMethod.trim() || access.trim()) {
+    if (
+      num(emd) > 0 ||
+      closeMethod.trim() ||
+      access.trim() ||
+      Object.keys(termsExtras).length > 0
+    ) {
       deal.terms = {
+        ...termsExtras,
         ...(num(emd) > 0 ? { emd: num(emd) } : {}),
         ...(closeMethod.trim() ? { closeMethod: closeMethod.trim() } : {}),
         ...(access.trim() ? { access: access.trim() } : {})
@@ -167,10 +249,11 @@ export function DealDeskForm({ config }: { config: DealsConfig }) {
     if (featured) deal.featured = true;
     return deal;
   }, [
-    id, status, isRental, isFlip, address, city, stateCode, zip, price, arv, estRehab,
-    beds, baths, sqft, lotSqft, yearBuilt, propertyType, occupancy, description,
-    highlightsText, photosText, monthlyRent, taxesAnnual, insuranceAnnual, hoaMonthly,
-    section8, emd, closeMethod, access, closeBy, featured
+    extras, rentalExtras, termsExtras, id, status, isRental, isFlip, address, city,
+    stateCode, zip, price, arv, estRehab, beds, baths, sqft, lotSqft, yearBuilt,
+    propertyType, occupancy, description, highlightsText, photosText, monthlyRent,
+    taxesAnnual, insuranceAnnual, hoaMonthly, section8, emd, closeMethod, access,
+    closeBy, featured
   ]);
 
   const activeDeal: unknown = useMemo(() => {
@@ -191,9 +274,7 @@ export function DealDeskForm({ config }: { config: DealsConfig }) {
   const preview = useMemo(() => {
     if (errors.length > 0 || !activeDeal) return null;
     const deal = activeDeal as Deal;
-    const fm = flipMath(deal);
-    const rm = rentalMath(deal);
-    return { fm, rm };
+    return { fm: flipMath(deal), rm: rentalMath(deal) };
   }, [errors, activeDeal]);
 
   const json = useMemo(
@@ -210,6 +291,71 @@ export function DealDeskForm({ config }: { config: DealsConfig }) {
   )}&value=${encodeURIComponent(json)}`;
   const githubUploadUrl = `https://github.com/${config.repo}/upload/main/public/deals/${dealId || ""}`;
 
+  const ready = errors.length === 0 && dealId.length > 0;
+  const idChangedWhileEditing = Boolean(editingId && dealId && dealId !== editingId);
+
+  async function publish() {
+    if (!ready || ship.status === "working") return;
+    setShip({ status: "working" });
+    try {
+      const res = await fetch("/api/deals-admin", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "same-origin",
+        body: JSON.stringify({ action: "upsert", id: dealId, deal: activeDeal })
+      });
+      const data = (await res.json().catch(() => null)) as
+        | { ok?: boolean; action?: string; error?: string; errors?: string[] }
+        | null;
+      if (res.ok && data?.ok) {
+        setShip({
+          status: "done",
+          id: dealId,
+          message: `${data.action === "update" ? "Updated" : "Published"} ${dealId} — Vercel is rebuilding, live in ~2 minutes.`
+        });
+      } else {
+        const detail = data?.errors?.length ? ` (${data.errors.join(" ")})` : "";
+        setShip({
+          status: "error",
+          message: `${data?.error ?? `Request failed (${res.status}).`}${detail}`
+        });
+      }
+    } catch {
+      setShip({ status: "error", message: "Network error — try again." });
+    }
+  }
+
+  async function removeDeal(targetId: string) {
+    if (!window.confirm(`Delete ${targetId} from the board? This removes its file from GitHub.`))
+      return;
+    setDeletingId(targetId);
+    try {
+      const res = await fetch("/api/deals-admin", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "same-origin",
+        body: JSON.stringify({ action: "delete", id: targetId })
+      });
+      const data = (await res.json().catch(() => null)) as
+        | { ok?: boolean; error?: string }
+        | null;
+      if (res.ok && data?.ok) {
+        setShip({
+          status: "done",
+          id: targetId,
+          message: `Deleted ${targetId} — Vercel is rebuilding, gone from the board in ~2 minutes.`
+        });
+        if (editingId === targetId) clearForm();
+      } else {
+        setShip({ status: "error", message: data?.error ?? `Delete failed (${res.status}).` });
+      }
+    } catch {
+      setShip({ status: "error", message: "Network error — try again." });
+    } finally {
+      setDeletingId(null);
+    }
+  }
+
   async function copyJson() {
     try {
       await navigator.clipboard.writeText(json);
@@ -220,32 +366,111 @@ export function DealDeskForm({ config }: { config: DealsConfig }) {
     }
   }
 
-  const ready = errors.length === 0 && dealId.length > 0;
-
   return (
     <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_380px]">
       <div className="space-y-5">
-        {/* Mode toggle */}
-        <div className="flex w-fit gap-1 rounded-full border border-slate-200 bg-white p-1">
-          {(
-            [
-              ["build", "Build a deal"],
-              ["paste", "Paste JSON (AI)"]
-            ] as const
-          ).map(([value, text]) => (
-            <button
-              key={value}
-              type="button"
-              onClick={() => setMode(value)}
-              className={`rounded-full px-4 py-2 text-sm font-semibold transition ${
-                mode === value
-                  ? "bg-zona-purple-deep text-white"
-                  : "text-slate-600 hover:text-zona-purple-deep"
-              }`}
-            >
-              {text}
-            </button>
-          ))}
+        {/* Manage existing deals */}
+        {deals.length > 0 && (
+          <div className={section}>
+            <p className={heading}>On the board now</p>
+            <ul className="space-y-2">
+              {deals.map((deal) => (
+                <li
+                  key={deal.id}
+                  className={`flex flex-wrap items-center justify-between gap-3 rounded-2xl border p-3 ${
+                    editingId === deal.id
+                      ? "border-zona-purple-mid bg-zona-purple-mid/5"
+                      : "border-slate-200"
+                  }`}
+                >
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-semibold text-zona-navy">
+                      {deal.address}
+                      <span className="ml-2 text-xs font-semibold uppercase tracking-wide text-slate-400">
+                        {deal.status}
+                      </span>
+                    </p>
+                    <p className="text-xs text-slate-500">
+                      {deal.city}, {deal.state} · {money(deal.price)}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={() => loadDeal(deal)}
+                      className="rounded-full border border-zona-purple-mid px-3 py-1.5 text-xs font-semibold text-zona-purple-mid transition hover:bg-zona-purple-mid/10"
+                    >
+                      Edit
+                    </button>
+                    <a
+                      href={`/deals/${deal.id}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="rounded-full border border-slate-300 px-3 py-1.5 text-xs font-semibold text-slate-600 transition hover:bg-slate-100"
+                    >
+                      View
+                    </a>
+                    {gatewayReady ? (
+                      <button
+                        type="button"
+                        onClick={() => removeDeal(deal.id)}
+                        disabled={deletingId === deal.id}
+                        className="rounded-full border border-zona-orange px-3 py-1.5 text-xs font-semibold text-zona-orange transition hover:bg-zona-orange/10 disabled:opacity-50"
+                      >
+                        {deletingId === deal.id ? "Deleting…" : "Delete"}
+                      </button>
+                    ) : (
+                      <a
+                        href={`https://github.com/${config.repo}/blob/main/content/deals/${deal.id}.json`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="rounded-full border border-slate-300 px-3 py-1.5 text-xs font-semibold text-slate-600 transition hover:bg-slate-100"
+                      >
+                        File →
+                      </a>
+                    )}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {/* Mode toggle + editing banner */}
+        <div className="flex flex-wrap items-center gap-3">
+          <div className="flex w-fit gap-1 rounded-full border border-slate-200 bg-white p-1">
+            {(
+              [
+                ["build", "Build a deal"],
+                ["paste", "Paste JSON (AI)"]
+              ] as const
+            ).map(([value, text]) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => setMode(value)}
+                className={`rounded-full px-4 py-2 text-sm font-semibold transition ${
+                  mode === value
+                    ? "bg-zona-purple-deep text-white"
+                    : "text-slate-600 hover:text-zona-purple-deep"
+                }`}
+              >
+                {text}
+              </button>
+            ))}
+          </div>
+          {editingId && (
+            <span className="flex items-center gap-2 rounded-full bg-zona-purple-mid/10 px-3 py-1.5 text-xs font-semibold text-zona-purple-deep">
+              Editing {editingId}
+              <button
+                type="button"
+                onClick={clearForm}
+                className="underline decoration-dotted underline-offset-2"
+              >
+                start fresh
+              </button>
+            </span>
+          )}
         </div>
 
         {mode === "paste" ? (
@@ -463,49 +688,129 @@ export function DealDeskForm({ config }: { config: DealsConfig }) {
 
         <div className={section}>
           <p className={heading}>Ship it</p>
-          <ol className="list-decimal space-y-1 pl-4 text-xs text-slate-600">
-            <li>Commit the JSON on GitHub (button below — everything is pre-filled).</li>
-            <li>Upload photos to public/deals/{dealId || "<id>"}/ if using local paths.</li>
-            <li>Vercel redeploys automatically — live in ~2 minutes.</li>
-          </ol>
-          <div className="space-y-2">
-            <a
-              href={ready ? githubNewFileUrl : undefined}
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-disabled={!ready}
-              className={`flex items-center justify-center rounded-full px-4 py-3 text-sm font-semibold transition ${
-                ready
-                  ? "bg-zona-purple-deep text-white hover:bg-zona-purple-mid"
-                  : "cursor-not-allowed bg-slate-200 text-slate-400"
-              }`}
-            >
-              Commit deal on GitHub →
-            </a>
-            <div className="grid grid-cols-2 gap-2">
+
+          {gatewayReady ? (
+            <>
               <button
                 type="button"
-                onClick={copyJson}
-                disabled={!ready}
-                className="flex items-center justify-center rounded-full border border-slate-300 px-4 py-2.5 text-sm font-semibold text-slate-700 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                {copied ? "Copied ✓" : "Copy JSON"}
-              </button>
-              <a
-                href={ready ? githubUploadUrl : undefined}
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-disabled={!ready}
-                className={`flex items-center justify-center rounded-full border px-4 py-2.5 text-sm font-semibold transition ${
-                  ready
-                    ? "border-slate-300 text-slate-700 hover:bg-slate-100"
-                    : "cursor-not-allowed border-slate-200 text-slate-400"
+                onClick={publish}
+                disabled={!ready || ship.status === "working"}
+                className={`flex w-full items-center justify-center rounded-full px-4 py-3 text-sm font-semibold transition ${
+                  ready && ship.status !== "working"
+                    ? "bg-zona-purple-deep text-white hover:bg-zona-purple-mid"
+                    : "cursor-not-allowed bg-slate-200 text-slate-400"
                 }`}
               >
-                Upload photos →
-              </a>
-            </div>
-          </div>
+                {ship.status === "working"
+                  ? "Publishing…"
+                  : editingId && !idChangedWhileEditing
+                    ? "Save changes to the board"
+                    : "Publish to the board"}
+              </button>
+              {idChangedWhileEditing && (
+                <p className="text-xs font-semibold text-zona-orange">
+                  The address/id changed — this publishes a NEW listing ({dealId}); {editingId}{" "}
+                  stays on the board until you delete it above.
+                </p>
+              )}
+              {ship.status === "done" && (
+                <p className="rounded-xl bg-green-50 p-3 text-xs font-semibold text-green-800">
+                  ✓ {ship.message}{" "}
+                  <a
+                    href={`/deals/${ship.id}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline"
+                  >
+                    View listing
+                  </a>
+                </p>
+              )}
+              {ship.status === "error" && (
+                <p className="rounded-xl bg-red-50 p-3 text-xs font-semibold text-red-800">
+                  {ship.message}
+                </p>
+              )}
+              <div className="grid grid-cols-2 gap-2">
+                <button
+                  type="button"
+                  onClick={copyJson}
+                  disabled={!ready}
+                  className="flex items-center justify-center rounded-full border border-slate-300 px-4 py-2.5 text-sm font-semibold text-slate-700 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {copied ? "Copied ✓" : "Copy JSON"}
+                </button>
+                <a
+                  href={ready ? githubUploadUrl : undefined}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-disabled={!ready}
+                  className={`flex items-center justify-center rounded-full border px-4 py-2.5 text-sm font-semibold transition ${
+                    ready
+                      ? "border-slate-300 text-slate-700 hover:bg-slate-100"
+                      : "cursor-not-allowed border-slate-200 text-slate-400"
+                  }`}
+                >
+                  Upload photos →
+                </a>
+              </div>
+              <p className="text-xs text-slate-500">
+                Publishing commits straight to GitHub as you — Vercel rebuilds and the board
+                updates in about two minutes.
+              </p>
+            </>
+          ) : (
+            <>
+              <p className="rounded-xl bg-zona-amber/10 p-3 text-xs font-semibold text-zona-navy">
+                One-click publishing is off — add a <code>GITHUB_DEALS_TOKEN</code> in Vercel to
+                enable it (steps in content/DEALS_README.md). The GitHub buttons below work in
+                the meantime.
+              </p>
+              <ol className="list-decimal space-y-1 pl-4 text-xs text-slate-600">
+                <li>Commit the JSON on GitHub (button below — everything is pre-filled).</li>
+                <li>Upload photos to public/deals/{dealId || "<id>"}/ if using local paths.</li>
+                <li>Vercel redeploys automatically — live in ~2 minutes.</li>
+              </ol>
+              <div className="space-y-2">
+                <a
+                  href={ready ? githubNewFileUrl : undefined}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-disabled={!ready}
+                  className={`flex items-center justify-center rounded-full px-4 py-3 text-sm font-semibold transition ${
+                    ready
+                      ? "bg-zona-purple-deep text-white hover:bg-zona-purple-mid"
+                      : "cursor-not-allowed bg-slate-200 text-slate-400"
+                  }`}
+                >
+                  Commit deal on GitHub →
+                </a>
+                <div className="grid grid-cols-2 gap-2">
+                  <button
+                    type="button"
+                    onClick={copyJson}
+                    disabled={!ready}
+                    className="flex items-center justify-center rounded-full border border-slate-300 px-4 py-2.5 text-sm font-semibold text-slate-700 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {copied ? "Copied ✓" : "Copy JSON"}
+                  </button>
+                  <a
+                    href={ready ? githubUploadUrl : undefined}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-disabled={!ready}
+                    className={`flex items-center justify-center rounded-full border px-4 py-2.5 text-sm font-semibold transition ${
+                      ready
+                        ? "border-slate-300 text-slate-700 hover:bg-slate-100"
+                        : "cursor-not-allowed border-slate-200 text-slate-400"
+                    }`}
+                  >
+                    Upload photos →
+                  </a>
+                </div>
+              </div>
+            </>
+          )}
         </div>
 
         {ready && (

--- a/app/(deals)/_lib/deal-shared.ts
+++ b/app/(deals)/_lib/deal-shared.ts
@@ -300,6 +300,43 @@ export function financedScenario(deal: Deal, rental: RentalMath): FinancedScenar
   };
 }
 
+// Lightweight mirror of content/deals/_SCHEMA.json. Used by the deal-desk
+// form for instant feedback AND by the /api/deals-admin gateway as the
+// server-side contract before anything is committed to GitHub.
+export function validateDeal(candidate: unknown): string[] {
+  const errors: string[] = [];
+  if (typeof candidate !== "object" || candidate === null) return ["Not a JSON object."];
+  const d = candidate as Record<string, unknown>;
+  const requireString = (key: string) => {
+    if (typeof d[key] !== "string" || (d[key] as string).length === 0)
+      errors.push(`"${key}" is required (text).`);
+  };
+  const requireNumber = (key: string, min = 0) => {
+    if (typeof d[key] !== "number" || (d[key] as number) < min)
+      errors.push(`"${key}" is required (number ≥ ${min}).`);
+  };
+  ["id", "address", "city", "state", "zip", "description"].forEach(requireString);
+  ["arv", "estRehab", "beds", "baths", "lotSqft", "yearBuilt"].forEach((k) => requireNumber(k));
+  ["price", "sqft"].forEach((k) => {
+    if (typeof d[k] !== "number" || (d[k] as number) <= 0)
+      errors.push(`"${k}" is required (number > 0).`);
+  });
+  if (typeof d.id === "string" && !/^[a-z0-9]+(-[a-z0-9]+)*$/.test(d.id))
+    errors.push('"id" must be lowercase letters/numbers with hyphens (e.g. 123-main-st).');
+  if (typeof d.state === "string" && !/^[A-Z]{2}$/.test(d.state))
+    errors.push('"state" must be a 2-letter code like MI.');
+  if (typeof d.zip === "string" && !/^\d{5}$/.test(d.zip)) errors.push('"zip" must be 5 digits.');
+  if (!["available", "pending", "sold"].includes(d.status as string))
+    errors.push('"status" must be available, pending, or sold.');
+  if (!Array.isArray(d.photos) || d.photos.length === 0)
+    errors.push('"photos" needs at least one path or URL.');
+  if (!Array.isArray(d.highlights)) errors.push('"highlights" must be a list of strings.');
+  const rental = d.rental as Record<string, unknown> | undefined;
+  if (rental && (typeof rental.monthlyRent !== "number" || rental.monthlyRent <= 0))
+    errors.push('"rental.monthlyRent" must be a number > 0 when a rental block is present.');
+  return errors;
+}
+
 export function googleMapsHref(deal: Deal): string {
   const query = encodeURIComponent(
     `${deal.address}, ${deal.city}, ${deal.state} ${deal.zip}`

--- a/app/(deals)/api/deals-admin/route.ts
+++ b/app/(deals)/api/deals-admin/route.ts
@@ -1,0 +1,135 @@
+// BREAKAWAY: deals board — remove at platform launch
+//
+// Owner-only gateway: lets /deal-desk create, update, and delete deal
+// files by committing to GitHub's contents API. This is the deals
+// group's ONLY server-side integration and it talks exclusively to
+// api.github.com — there is still no platform backend involved.
+//
+// Auth: the same owner-access cookie that gates the site (verified
+// here directly — middleware also screens non-owners, this is defense
+// in depth). Credentials: a fine-grained GitHub PAT with Contents
+// read/write on the deals repo, stored as GITHUB_DEALS_TOKEN in Vercel.
+// Every commit to main triggers the normal Vercel rebuild, so changes
+// go live the same way a hand-made GitHub edit would.
+
+import { NextRequest, NextResponse } from "next/server";
+import { OWNER_COOKIE_NAME, verifyOwnerCookie } from "@/lib/owner-auth";
+import configRaw from "@/content/deals-config.json";
+import { validateDeal } from "../../_lib/deal-shared";
+
+const ID_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
+const GITHUB_HEADERS = (token: string) => ({
+  Authorization: `Bearer ${token}`,
+  Accept: "application/vnd.github+json",
+  "X-GitHub-Api-Version": "2022-11-28"
+});
+
+async function getExistingSha(
+  repo: string,
+  path: string,
+  token: string
+): Promise<string | undefined> {
+  const res = await fetch(
+    `https://api.github.com/repos/${repo}/contents/${path}?ref=main`,
+    { headers: GITHUB_HEADERS(token), cache: "no-store" }
+  );
+  if (!res.ok) return undefined;
+  const body = (await res.json()) as { sha?: string };
+  return body.sha;
+}
+
+export async function POST(req: NextRequest) {
+  const cookie = req.cookies.get(OWNER_COOKIE_NAME)?.value;
+  if (!(await verifyOwnerCookie(cookie))) {
+    return NextResponse.json({ error: "Not authorized." }, { status: 401 });
+  }
+
+  const token = process.env.GITHUB_DEALS_TOKEN;
+  if (!token) {
+    return NextResponse.json(
+      {
+        error:
+          "Gateway not configured — add a GITHUB_DEALS_TOKEN environment variable in Vercel (fine-grained PAT, Contents read/write on the deals repo) and redeploy."
+      },
+      { status: 503 }
+    );
+  }
+
+  let body: { action?: string; id?: string; deal?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  const { action, id, deal } = body;
+  if (typeof id !== "string" || !ID_PATTERN.test(id)) {
+    return NextResponse.json(
+      { error: "Invalid deal id (lowercase letters/numbers/hyphens only)." },
+      { status: 400 }
+    );
+  }
+
+  const repo: string = configRaw.repo;
+  const path = `content/deals/${id}.json`;
+
+  if (action === "delete") {
+    const sha = await getExistingSha(repo, path, token);
+    if (!sha) {
+      return NextResponse.json({ error: `No deal file found for "${id}".` }, { status: 404 });
+    }
+    const res = await fetch(`https://api.github.com/repos/${repo}/contents/${path}`, {
+      method: "DELETE",
+      headers: GITHUB_HEADERS(token),
+      body: JSON.stringify({
+        message: `deal-desk: remove ${id}`,
+        sha,
+        branch: "main"
+      })
+    });
+    if (!res.ok) {
+      const detail = ((await res.json().catch(() => null)) as { message?: string })?.message;
+      return NextResponse.json(
+        { error: `GitHub rejected the delete (${res.status}${detail ? `: ${detail}` : ""}).` },
+        { status: 502 }
+      );
+    }
+    return NextResponse.json({ ok: true, action: "delete", id });
+  }
+
+  if (action === "upsert") {
+    const errors = validateDeal(deal);
+    if (errors.length > 0) {
+      return NextResponse.json({ error: "Deal failed validation.", errors }, { status: 400 });
+    }
+    if ((deal as { id: string }).id !== id) {
+      return NextResponse.json(
+        { error: "Deal id does not match the target file id." },
+        { status: 400 }
+      );
+    }
+    const sha = await getExistingSha(repo, path, token);
+    const content = Buffer.from(JSON.stringify(deal, null, 2) + "\n", "utf8").toString("base64");
+    const res = await fetch(`https://api.github.com/repos/${repo}/contents/${path}`, {
+      method: "PUT",
+      headers: GITHUB_HEADERS(token),
+      body: JSON.stringify({
+        message: `deal-desk: ${sha ? "update" : "add"} ${id}`,
+        content,
+        branch: "main",
+        ...(sha ? { sha } : {})
+      })
+    });
+    if (!res.ok) {
+      const detail = ((await res.json().catch(() => null)) as { message?: string })?.message;
+      return NextResponse.json(
+        { error: `GitHub rejected the commit (${res.status}${detail ? `: ${detail}` : ""}).` },
+        { status: 502 }
+      );
+    }
+    return NextResponse.json({ ok: true, action: sha ? "update" : "create", id });
+  }
+
+  return NextResponse.json({ error: 'Unknown action — use "upsert" or "delete".' }, { status: 400 });
+}

--- a/app/(deals)/deal-desk/page.tsx
+++ b/app/(deals)/deal-desk/page.tsx
@@ -7,7 +7,7 @@
 
 import type { Metadata } from "next";
 import { DealDeskForm } from "../_components/DealDeskForm";
-import { getDealsConfig, sora } from "../_lib/deals";
+import { getDeals, getDealsConfig, sora } from "../_lib/deals";
 
 export const metadata: Metadata = {
   title: "Deal Desk | Zona Desert",
@@ -16,6 +16,10 @@ export const metadata: Metadata = {
 
 export default function DealDeskPage() {
   const config = getDealsConfig();
+  const deals = getDeals();
+  // Baked in at build time — setting the env var + redeploying flips it,
+  // and every gateway commit triggers a rebuild anyway.
+  const gatewayReady = Boolean(process.env.GITHUB_DEALS_TOKEN);
   return (
     <div className="mx-auto w-full max-w-6xl px-4 py-8 md:py-12">
       <p className="text-xs uppercase tracking-[0.35em] text-zona-purple-mid">Owner tools</p>
@@ -28,7 +32,7 @@ export default function DealDeskPage() {
         Photos upload separately to <code className="rounded bg-white px-1.5 py-0.5 text-xs">public/deals/&lt;id&gt;/</code>.
       </p>
       <div className="mt-8">
-        <DealDeskForm config={config} />
+        <DealDeskForm config={config} deals={deals} gatewayReady={gatewayReady} />
       </div>
     </div>
   );

--- a/content/DEALS_README.md
+++ b/content/DEALS_README.md
@@ -12,13 +12,36 @@ ways to do it, easiest first.
    as always, 90-day cookie).
 2. Go to **`zonadesert.com/deal-desk`** — visitors without your login just get
    bounced to the public board, so this page is yours alone.
-3. Fill in the form. Cap rate, NOI, cash flow, and spread compute live as you
-   type, so you can sanity-check the deal before it ships.
-4. Click **Commit deal on GitHub** — GitHub opens with the file name and
-   contents already filled in. Scroll down, click **Commit changes**. Done.
+3. **Add:** fill in the form. Cap rate, NOI, cash flow, and spread compute
+   live as you type. Hit **Publish to the board**.
+4. **Edit / delete:** the "On the board now" list at the top shows every live
+   deal — **Edit** loads it into the form (change anything, hit *Save
+   changes*), **Delete** removes it after a confirmation. Changing the address
+   while editing creates a NEW listing (the desk warns you); delete the old
+   one from the list.
 5. If you used local photo paths, click **Upload photos** and drag the images
    into `public/deals/<deal-id>/` (name them `1.jpg`, `2.jpg`, … — the first
    one is the cover).
+
+Everything the desk publishes is a real GitHub commit under your account, so
+the repo history stays the audit log.
+
+### One-time setup for one-click publishing (GITHUB_DEALS_TOKEN)
+
+The desk commits through GitHub's API using a token. Until the token exists,
+the desk falls back to "open GitHub with everything pre-filled" buttons.
+
+1. Go to **github.com → Settings → Developer settings → Personal access
+   tokens → Fine-grained tokens → Generate new token**.
+2. Name: `zona-deal-desk`. Expiration: 1 year (calendar a renewal).
+3. **Repository access:** Only select repositories → `zona-desert-site`.
+4. **Permissions → Repository permissions → Contents: Read and write.**
+   Nothing else.
+5. Generate, copy the token (starts with `github_pat_`).
+6. In **Vercel → zona-desert-site → Settings → Environment Variables**, add
+   `GITHUB_DEALS_TOKEN` = the token, **Production** scope. Save.
+7. Redeploy (Deployments → ⋯ → Redeploy). The desk's publish button goes
+   live on the next load.
 
 ## Way 2 — Ask an AI to write the deal
 


### PR DESCRIPTION
## What this adds

The deal desk becomes full CRUD **under zonadesert.com** — no more GitHub tab for routine work:

- **`/api/deals-admin`** (in the `(deals)` group, BREAKAWAY-marked): owner-cookie-authenticated route that creates/updates/deletes `content/deals/<id>.json` via GitHub's contents API using a fine-grained PAT (`GITHUB_DEALS_TOKEN` in Vercel). Commits land on main as the owner → normal Vercel rebuild → live in ~2 min. Repo history stays the audit log.
- **"On the board now"** manager at the top of `/deal-desk`: every live deal with **Edit** (loads into the form — fields the form doesn't manage, like comps/financing/expense-% overrides, are preserved untouched), **View**, and **Delete** (with confirmation).
- **Publish / Save changes** button with clear success/error states; warns when the address/id changed mid-edit (that publishes a new listing rather than renaming).
- **Graceful fallback:** without the token, the desk shows a setup note and keeps the old prefilled-GitHub-links flow fully working.
- Validation moved to `deal-shared.ts` — the same contract runs client-side (instant feedback) and server-side (nothing invalid can be committed).

## Security

- Middleware screens non-owners before the route is reachable (verified: anonymous POST → 307 to the board); the route independently re-verifies the owner cookie (401) as defense in depth.
- Deal ids validated against `^[a-z0-9]+(-[a-z0-9]+)*$` — no path traversal into the repo.
- Token is a fine-grained PAT scoped to this repo, Contents read/write only; setup + revocation steps documented in DEALS_README / DEALS_BREAKAWAY.

## Verification

- Anonymous requests to the gateway blocked by middleware (307) — verified locally.
- Cookie signing/verification logic verified offline against the env secret.
- CI (lint + type-check + build) is the gate for this PR; full e2e publish requires the production `GITHUB_DEALS_TOKEN`, which only the owner can create — first real publish after merge is the final check.

## After merge (owner setup, ~2 min)

1. GitHub → Settings → Developer settings → Fine-grained tokens → new token `zona-deal-desk`, repo-scoped to `zona-desert-site`, **Contents: Read and write** only.
2. Vercel → zona-desert-site → Settings → Environment Variables → `GITHUB_DEALS_TOKEN` (Production) → Redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)